### PR TITLE
Only get primary entrances for spoiler log

### DIFF
--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -304,6 +304,8 @@ def set_shuffled_entrances(entrance_pools: EntrancePools) -> None:
     for pool in entrance_pools.values():
         for entrance in pool:
             entrance.shuffled = True
+            if entrance.reverse:
+                entrance.reverse.shuffled = True
 
 
 def check_entrances_compatibility(entrance: Entrance, target: Entrance) -> None:

--- a/logic/spoiler_log.py
+++ b/logic/spoiler_log.py
@@ -76,14 +76,16 @@ def generate_spoiler_log(worlds: list[World]) -> None:
 
         # Recalculate longest name length for all shuffled entrances
         for world in worlds:
-            for entrance in world.get_shuffled_entrances():
+            for entrance in world.get_shuffled_entrances(only_primary=True):
                 longest_name_length = max(longest_name_length, len(f"{entrance}"))
 
-        if len(worlds[0].entrance_spheres) > 0:
+        if any(
+            [len(world.get_shuffled_entrances(only_primary=True)) for world in worlds]
+        ):
             spoiler_log.write("\nAll Entrances:\n")
         for world in worlds:
             spoiler_log.write(f"    {world}:\n")
-            for entrance in sorted(world.get_shuffled_entrances()):
+            for entrance in sorted(world.get_shuffled_entrances(only_primary=True)):
                 spoiler_log.write(
                     "        "
                     + spoiler_format_entrance(entrance, longest_name_length)

--- a/logic/world.py
+++ b/logic/world.py
@@ -483,10 +483,8 @@ class World:
                     entrances.append(exit_)
         return entrances
 
-    def get_shuffled_entrances(self) -> list[Entrance]:
-        entrances = []
-        for area in self.areas.values():
-            for exit_ in area.exits:
-                if exit_.shuffled:
-                    entrances.append(exit_)
-        return entrances
+    def get_shuffled_entrances(
+        self, entrance_type: int = EntranceType.ALL, only_primary: bool = False
+    ) -> list[Entrance]:
+        entrances = self.get_shuffleable_entrances(entrance_type, only_primary)
+        return [e for e in entrances if e.shuffled]


### PR DESCRIPTION
Listing entrances both ways in the log clutters it with unnecessary info