### PR TITLE
Door Entrance Rando

### DIFF
--- a/data/entrance_shuffle_data.yaml
+++ b/data/entrance_shuffle_data.yaml
@@ -453,3 +453,522 @@
         layer: 0
         room: 0
         entrance: 4
+
+###############################
+#            DOORS            #
+###############################
+
+- type: Door
+  door_couple_tag: Knight Academy Lower
+  forward: 
+    connection: Upper Skyloft -> Knight Academy Lower East Door
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 3
+    spawn_info:
+      - stage: F001r
+        layer: 0
+        room: 0
+        entrance: 2
+  return:
+    connection: Knight Academy -> Knight Academy Lower East Door
+    exit_infos:
+      - stage: F001r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 4
+- type: Door
+  door_couple_tag: Knight Academy Lower
+  forward:
+    connection: Upper Skyloft -> Knight Academy Lower West Door
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 4
+    spawn_info:
+      - stage: F001r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Knight Academy -> Knight Academy Lower West Door
+    exit_infos:
+      - stage: F001r
+        room: 0
+        index: 1
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 5
+- type: Door
+  door_couple_tag: Knight Academy Upper
+  forward:
+    connection: Upper Skyloft -> Knight Academy Upper North Door
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 24
+    spawn_info:
+      - stage: F001r
+        layer: 0
+        room: 0
+        entrance: 4
+  return:  
+    connection: Knight Academy -> Knight Academy Upper North Door
+    exit_infos:
+      - stage: F001r
+        room: 0
+        index: 3
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 24
+- type: Door
+  door_couple_tag: Knight Academy Upper
+  forward:
+    connection: Upper Skyloft -> Knight Academy Upper South Door
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 23
+    spawn_info:
+      - stage: F001r
+        layer: 0
+        room: 0
+        entrance: 3
+  return:  
+    connection: Knight Academy -> Knight Academy Upper South Door
+    exit_infos:
+      - stage: F001r
+        room: 0
+        index: 2
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 23
+- type: Door
+  door_couple_tag: Sparring Hall
+  forward:
+    connection: Upper Skyloft -> Sparring Hall North Door
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 27
+    spawn_info:
+      - stage: F009r
+        layer: 0
+        room: 0
+        entrance: 2
+  return:  
+    connection: Sparring Hall -> Sparring Hall North Door
+    exit_infos:
+      - stage: F009r
+        room: 0
+        index: 1
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 26
+- type: Door
+  door_couple_tag: Sparring Hall
+  forward:
+    connection: Upper Skyloft -> Sparring Hall South Door
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 20
+    spawn_info:
+      - stage: F009r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Sparring Hall -> Sparring Hall South Door
+    exit_infos:
+      - stage: F009r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 21
+- type: Door
+  forward:
+    connection: Central Skyloft -> Orielle and Parrow's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 31
+    spawn_info:
+      - stage: F005r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Orielle and Parrow's House -> Central Skyloft
+    exit_infos:
+      - stage: F005r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 30
+- type: Door
+  forward:
+    connection: Central Skyloft -> Peatrice's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 38
+    spawn_info:
+      - stage: F018r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Peatrice's House -> Central Skyloft
+    exit_infos:
+      - stage: F018r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 38
+- type: Door
+  forward:
+    connection: Central Skyloft -> Wryna's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 10
+    spawn_info:
+      - stage: F006r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Wryna's House -> Central Skyloft
+    exit_infos:
+      - stage: F006r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 31
+- type: Door
+  forward:
+    connection: Central Skyloft -> Piper's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 32
+    spawn_info:
+      - stage: F007r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Piper's House -> Central Skyloft
+    exit_infos:
+      - stage: F007r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 32
+- type: Door
+  forward:
+    connection: Skyloft Village -> Bertie's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 34
+    spawn_info:
+      - stage: F014r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Bertie's House -> Skyloft Village
+    exit_infos:
+      - stage: F014r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 34
+- type: Door
+  forward:
+    connection: Skyloft Village -> Sparrot's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 33
+    spawn_info:
+      - stage: F013r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Sparrot's House -> Skyloft Village
+    exit_infos:
+      - stage: F013r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 33
+- type: Door
+  forward:
+    connection: Skyloft Village -> Mallara's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 36
+    spawn_info:
+      - stage: F016r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Mallara's House -> Skyloft Village
+    exit_infos:
+      - stage: F016r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 36
+- type: Door
+  forward:
+    connection: Skyloft Village -> Gondo's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 35
+    spawn_info:
+      - stage: F015r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Gondo's House -> Skyloft Village
+    exit_infos:
+      - stage: F015r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 35
+- type: Door
+  forward:
+    connection: Skyloft Village -> Rupin's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 37
+    spawn_info:
+      - stage: F017r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Rupin's House -> Skyloft Village
+    exit_infos:
+      - stage: F017r
+        room: 0
+        index: 1
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 37
+- type: Door
+  forward:
+    connection: Skyloft Village -> Batreaux's House
+    exit_infos: 
+      - stage: F000
+        room: 0
+        index: 30
+    spawn_info:
+      - stage: F012r
+        layer: 0
+        room: 0
+        entrance: 0
+  return:  
+    connection: Batreaux's House -> Skyloft Village
+    exit_infos:
+      - stage: F012r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F000
+        layer: 0
+        room: 0
+        entrance: 29
+- type: Door
+  door_couple_tag: Lumpy Pumpkin
+  forward:
+    connection: Lumpy Pumpkin Exterior -> Lumpy Pumpkin Main East Door
+    exit_infos: 
+      - stage: F020
+        room: 0
+        index: 18
+    spawn_info:
+      - stage: F011r
+        layer: 0
+        room: 0
+        entrance: 2
+  return:  
+    connection: Lumpy Pumpkin Interior -> Lumpy Pumpkin Main East Door
+    exit_infos:
+      - stage: F011r
+        room: 0
+        index: 1
+    spawn_info:
+      - stage: F020
+        layer: 0
+        room: 0
+        entrance: 23
+- type: Door
+  door_couple_tag: Lumpy Pumpkin
+  forward:
+    connection: Lumpy Pumpkin Exterior -> Lumpy Pumpkin Main West Door
+    exit_infos: 
+      - stage: F020
+        room: 0
+        index: 19
+    spawn_info:
+      - stage: F011r
+        layer: 0
+        room: 0
+        entrance: 1
+  return:  
+    connection: Lumpy Pumpkin Interior -> Lumpy Pumpkin Main West Door
+    exit_infos:
+      - stage: F011r
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F020
+        layer: 0
+        room: 0
+        entrance: 22
+- type: Door
+  forward:
+    connection: Lumpy Pumpkin Exterior -> Lumpy Pumpkin Back Door
+    exit_infos: 
+      - stage: F020
+        room: 0
+        index: 20
+    spawn_info:
+      - stage: F011r
+        layer: 0
+        room: 0
+        entrance: 3
+  return:  
+    connection: Lumpy Pumpkin Interior -> Lumpy Pumpkin Back Door
+    exit_infos:
+      - stage: F011r
+        room: 0
+        index: 2
+    spawn_info:
+      - stage: F020
+        layer: 0
+        room: 0
+        entrance: 24
+- type: Door
+  forward:
+    connection: Sealed Grounds Spiral -> Sealed Temple
+    exit_infos: 
+      - stage: F401
+        room: 1
+        index: 0
+    spawn_info:
+      - stage: F402
+        layer: 0
+        room: 2
+        entrance: 0
+  return:  
+    connection: Sealed Temple -> Sealed Grounds Spiral
+    exit_infos:
+      - stage: F402
+        room: 2
+        index: 0
+    spawn_info:
+      - stage: F401
+        layer: 0
+        room: 1
+        entrance: 2
+- type: Door
+  forward:
+    connection: Behind the Temple -> Sealed Temple
+    exit_infos: 
+      - stage: F400
+        room: 0
+        index: 1
+    spawn_info:
+      - stage: F402
+        layer: 0
+        room: 2
+        entrance: 1
+  return:  
+    connection: Sealed Temple -> Behind the Temple
+    exit_infos:
+      - stage: F402
+        room: 2
+        index: 1
+    spawn_info:
+      - stage: F400
+        layer: 0
+        room: 0
+        entrance: 1
+- type: Door
+  forward:
+    connection: Skipper's Retreat Top -> Skipper's Retreat Shack
+    exit_infos: 
+      - stage: F301_3
+        room: 0
+        index: 3
+    spawn_info:
+      - stage: F301_5
+        layer: 0
+        room: 0
+        entrance: 0
+  return:  
+    connection: Skipper's Retreat Shack -> Skipper's Retreat Top
+    exit_infos:
+      - stage: F301_5
+        room: 0
+        index: 0
+    spawn_info:
+      - stage: F301_3
+        layer: 0
+        room: 0
+        entrance: 1

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -180,6 +180,26 @@
     - off/on:                       "empty description"
 
 
+- name: randomize_door_entrances
+  default_option: 'off'
+  pretty_name: Randomize Door Entrances
+  pretty_options:
+    - 'Off'
+    - 'On'
+  options:
+    - off/on:                       "empty description"
+
+
+- name: decouple_double_doors
+  default_option: 'off'
+  pretty_name: Decouple Double Doors
+  pretty_options:
+    - 'Off'
+    - 'On'
+  options:
+    - off/on:                       "empty description"
+
+
 - name: scrap_shop_upgrades
   default_option: 'on'
   pretty_name: Place Scrap Shop Upgrades

--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -34,9 +34,8 @@
     Start Imprisoned 2: "'Raise_Gate_of_Time' and Master_Sword" # TODO
     Open Gate of Time: "'Can_Defeat_Imprisoned_2' and Master_Sword" # TODO
   exits:
-    Sealed Grounds: Nothing
-    Behind the Temple North Door: Nothing
-    Behind the Temple South Door: Nothing
+    Sealed Grounds Spiral: Nothing
+    Behind the Temple: Nothing
     Hylia's Temple: "'Open_Gate_of_Time'"
   locations:
     Sealed Temple - Chest: Nothing
@@ -52,24 +51,23 @@
     Hylia's Realm - Defeat Demise: Sword and Complete_Triforce # TODO
 
 
-- name: Behind the Temple North Door
-  exits:
-    Sealed Temple: Nothing
-    Behind the Temple: Nothing
+# - name: Behind the Temple North Door
+#   exits:
+#     Sealed Temple: Nothing
+#     Behind the Temple: Nothing
 
 
-- name: Behind the Temple South Door
-  exits:
-    Sealed Temple: Nothing
-    Behind the Temple: Nothing
+# - name: Behind the Temple South Door
+#   exits:
+#     Sealed Temple: Nothing
+#     Behind the Temple: Nothing
 
 
 - name: Behind the Temple
   hint_region: Sealed Grounds
   exits:
     Behind the Temple Statue: Nothing
-    Behind the Temple North Door: Nothing
-    Behind the Temple South Door: Nothing
+    Sealed Temple: Nothing
     Faron Woods Entry: Nothing
     Sealed Grounds Upper Ledge: Nothing
   locations:

--- a/data/world/Sky.yaml
+++ b/data/world/Sky.yaml
@@ -124,9 +124,9 @@
     Start Kinas Quest: Day and 'Complete_Hot_Soup_Delivery'
     Pumpkin Carrying: Day and 'Complete_Hot_Soup_Delivery'
   exits:
-    Lumpy Pumpkin North Door: Nothing
-    Lumpy Pumpkin Southeast Door: Nothing
-    Lumpy Pumpkin Southwest Door: Nothing
+    Lumpy Pumpkin Back Door: Nothing
+    Lumpy Pumpkin Main East Door: Nothing
+    Lumpy Pumpkin Main West Door: Nothing
     The Sky: Day
   locations:
     Lumpy Pumpkin - Outside Crystal: Night
@@ -136,17 +136,17 @@
     Lumpy Pumpkin - Gossip Stone: Nothing
 
 
-- name: Lumpy Pumpkin North Door
+- name: Lumpy Pumpkin Back Door
   exits:
     Lumpy Pumpkin Exterior: Nothing
     Lumpy Pumpkin Interior: Nothing
 
-- name: Lumpy Pumpkin Southeast Door
+- name: Lumpy Pumpkin Main East Door
   exits:
     Lumpy Pumpkin Exterior: Nothing
     Lumpy Pumpkin Interior: Nothing
 
-- name: Lumpy Pumpkin Southwest Door
+- name: Lumpy Pumpkin Main West Door
   exits:
     Lumpy Pumpkin Exterior: Nothing
     Lumpy Pumpkin Interior: Nothing
@@ -159,9 +159,9 @@
     Complete Hot Soup Delivery: "'Delivered_Hot_Soup'"
     Pick up Levias Soup: Spiral_Charge
   exits:
-    Lumpy Pumpkin North Door: Nothing
-    Lumpy Pumpkin Southeast Door: Nothing
-    Lumpy Pumpkin Southwest Door: Nothing
+    Lumpy Pumpkin Back Door: Nothing
+    Lumpy Pumpkin Main East Door: Nothing
+    Lumpy Pumpkin Main West Door: Nothing
   locations:
     Lumpy Pumpkin - Chandelier: Nothing
     Lumpy Pumpkin - Inside Crystal: Night

--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -1,5 +1,5 @@
 - name: Root
-  allowed_time_of_day: Day Only
+  allowed_time_of_day: All
   exits:
     Link's Spawn: Nothing
 
@@ -388,7 +388,7 @@
 
 
 - name: Skyloft Past Waterfall Cave Jump
-  hint_regin: None # Prevent Skyloft Past Waterfall Cave from being assigned to Skyloft Village
+  hint_region: None # Prevent Skyloft Past Waterfall Cave from being assigned to Skyloft Village
   exits:
     Skyloft Past Waterfall Cave: Nothing
 

--- a/logic/entrance.py
+++ b/logic/entrance.py
@@ -15,9 +15,11 @@ class EntranceType:
     DUNGEON_REVERSE: int = 4
     TRIAL_GATE: int = 5
     TRIAL_GATE_REVERSE: int = 6
-    INTERIOR: int = 7
-    INTERIOR_REVERSE: int = 8
-    OVERWORLD: int = 9
+    DOOR: int = 7
+    DOOR_REVERSE: int = 8
+    INTERIOR: int = 9
+    INTERIOR_REVERSE: int = 10
+    OVERWORLD: int = 11
 
     MIXED: int = 20
 
@@ -31,6 +33,8 @@ class EntranceType:
                 return EntranceType.DUNGEON
             case "Trial Gate":
                 return EntranceType.TRIAL_GATE
+            case "Door":
+                return EntranceType.DOOR
             case "Interior":
                 return EntranceType.INTERIOR
             case "Overworld":
@@ -58,9 +62,9 @@ class Entrance:
         self.requirement: Requirement = requirement_
         self.world: "World" = world_
 
-        self.exit_infos = {}
+        self.exit_infos = []
         self.spawn_info = {}
-        self.secondary_exit_infos = {}
+        self.secondary_exit_infos = []
         self.secondary_spawn_info = {}
 
         # Variables used for entrance shuffling

--- a/logic/world.py
+++ b/logic/world.py
@@ -461,9 +461,8 @@ class World:
         return SettingGet(setting_name, self.setting_map.settings[setting_name])
 
     def set_search_starting_properties(self, search: "Search"):
-        # Set the root to have daytime
-        # TODO: Change if we ever have an option to start at night
-        search.area_time[self.root.id] = TOD.DAY
+        # Set the root to have all times of day (necessary for entrance rando)
+        search.area_time[self.root.id] = TOD.ALL
 
     def get_shuffleable_entrances(
         self,


### PR DESCRIPTION
- Batreaux can now reside at Skipper's Retreat
- Adds an option to shuffle door entrances
- Adds an additional option to decouple double doors from each other which is off by default
- Tested every door entrance and all seemed good