### PR TITLE
Rename Baby's Rattle ->Rattle (to match vanilla)

### DIFF
--- a/asm/additions/rust-additions/src/structs.rs
+++ b/asm/additions/rust-additions/src/structs.rs
@@ -299,7 +299,7 @@ pub enum ITEMFLAGS {
     UNK157                           = 0x9D,
     CAWLIN_LETTER                    = 0x9E,
     HORNED_COLOSSUS_BEETLE           = 0x9F,
-    BABY_RATTLE                      = 0xA0,
+    RATTLE                           = 0xA0,
     HORNET_LAVAE                     = 0xA1,
     BIRD_FEATHER                     = 0xA2,
     TUMBLEWEED                       = 0xA3,

--- a/asm/patches/freestanding-items.asm
+++ b/asm/patches/freestanding-items.asm
@@ -26,7 +26,7 @@ fmov s0, 0x40000000 ; 2.0
 orr w19, w1, #0x200 ; the 9th bit (zero-indexed)
 
 
-; Always act like Baby Rattle
+; Always act like Rattle
 
 ; dAcItem::init
 .offset 0x084e4e54

--- a/constants/itemconstants.py
+++ b/constants/itemconstants.py
@@ -34,7 +34,7 @@ LIFE_TREE_SEEDLING = "Life Tree Seedling"
 STONE_OF_TRIALS = "Stone of Trials"
 CAWLINS_LETTER = "Cawlin's Letter"
 HORNED_COLOSSUS_BEETLE = "Horned Colossus Beetle"
-BABYS_RATTLE = "Baby's Rattle"
+RATTLE = "Rattle"
 SEA_CHART = "Sea Chart"
 SPIRAL_CHARGE = "Spiral Charge"
 HYLIAN_SHIELD = "Hylian Shield"
@@ -87,7 +87,7 @@ ITEM_ITEMFLAGS = {
     STONE_OF_TRIALS: 180,
     CAWLINS_LETTER: 158,
     HORNED_COLOSSUS_BEETLE: 159,
-    BABYS_RATTLE: 160,
+    RATTLE: 160,
     SEA_CHART: 98,
     TRIFORCE_OF_COURAGE: 95,
     TRIFORCE_OF_POWER: 96,
@@ -144,7 +144,7 @@ FREESTANDING_ITEMS_TO_USE_DEFAULT_SCALING = [
     95,  # Triforce of Courage
     96,  # Triforce of Power
     97,  # Triforce of Wisdom
-    160,  # Baby's Rattle
+    160,  # Rattle
 ]
 
 FREESTANDING_ITEM_OFFSETS = {
@@ -266,7 +266,7 @@ FREESTANDING_ITEM_OFFSETS = {
     153: 16.0,  # Empty Bottle
     158: 12.0,  # Cawlin's Letter
     159: 20.0,  # Horned Colossus Beetle
-    160: 5.0,  # Baby's Rattle
+    160: 5.0,  # Rattle
     161: 16.0,  # Hornet Larvae (unused)
     162: 16.0,  # Bird Feather (unused)
     163: 16.0,  # Tumbleweed

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -398,7 +398,7 @@
   getmodelname: GetTerryCage
   advancement: true
 - id: 160
-  name: Baby's Rattle
+  name: Rattle
   oarc:
   - GetGaragara
   - PutGaragara

--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -227,7 +227,7 @@
   text: the <r<item check girl>> hides
 
 - name: Central Skyloft - Item in Bird Nest
-  original_item: Baby's Rattle
+  original_item: Rattle
   type:
   Paths:
     - stage/F000/r0/l0/Item/13

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -424,9 +424,9 @@
   - off/on:                 "empty description"
 
 
-- name: logic_baby_rattle_from_beedles_shop
+- name: logic_bird_nest_item_from_beedles_shop
   default_option: "off"
-  pretty_name: Baby Rattle from Beetle's Shop
+  pretty_name: Bird's Nest Item from Beetle's Shop
   pretty_options:
     - "Off"
     - "On"

--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -155,7 +155,7 @@
     Sky Keep Entrance Platform: Day and Clawshots
     Waterfall Island: Clawshots
     Waterfall Cave: Can_Cut_Trees_And_Logs
-    Bird Nest: logic_baby_rattle_from_beedles_shop and Day and Distance_Activator and (Beetle or Whip)
+    Bird Nest: logic_bird_nest_item_from_beedles_shop and Day and Distance_Activator and (Beetle or Whip)
   locations:
     Central Skyloft - Crystal between Wooden Planks: Night
     Central Skyloft - Crystal on West Cliff: Night
@@ -335,7 +335,7 @@
   exits:
     Skyloft Village: Nothing
   locations:
-    Skyloft Village - Bertie's Crystals: Babys_Rattle and Night
+    Skyloft Village - Bertie's Crystals: Rattle and Night
 
 
 - name: Sparrot's House

--- a/logic/item_pool.py
+++ b/logic/item_pool.py
@@ -59,7 +59,7 @@ def generate_item_pool(world: "World") -> None:
             "Emerald Tablet",
             "Ruby Tablet",
             "Amber Tablet",
-            "Babys Rattle",
+            "Rattle",
             "Cawlin's Letter",
             "Horned Colossus Beetle",
             "Sea Chart",


### PR DESCRIPTION
`Baby's Rattle` is just called `Rattle` in the base game so I've renamed it to match