### PR TITLE
Goddess Cubes as Locations

### DIFF
--- a/data/items.yaml
+++ b/data/items.yaml
@@ -622,3 +622,112 @@
   oarc: null
   game_winning_item: true
   advancement: true
+# Dummy items (for now) to simulate hitting goddess cubes
+- id: 257
+  name: Faron Woods Goddess Cube on West Great Tree near Exit
+  oarc: null
+  advancement: true
+- id: 258
+  name: Faron Woods Goddess Cube on East Great Tree with Clawshots Target
+  oarc: null
+  advancement: true
+- id: 259
+  name: Faron Woods Goddess Cube on East Great Tree with Rope
+  oarc: null
+  advancement: true
+- id: 260
+  name: Deep Woods Goddess Cube Near Goron
+  oarc: null
+  advancement: true
+- id: 261
+  name: Deep Woods Goddess Cube in front of Skyview
+  oarc: null
+  advancement: true
+- id: 262
+  name: Deep Woods Goddess Cube on top of Skyview
+  oarc: null
+  advancement: true
+- id: 263
+  name: Lake Floria Goddess Cube
+  oarc: null
+  advancement: true
+- id: 264
+  name: Floria Waterfall Goddess Cube on High Ledge
+  oarc: null
+  advancement: true
+- id: 265
+  name: Eldin Volcano Goddess Cube at Eldin Entrance
+  oarc: null
+  advancement: true
+- id: 266
+  name: Eldin Volcano Goddess Cube near Mogma Turf Entrance
+  oarc: null
+  advancement: true
+- id: 267
+  name: Eldin Volcano Goddess Cube West of Earth Temple Entrance
+  oarc: null
+  advancement: true
+- id: 268
+  name: Eldin Volcano Goddess Cube East of Earth Temple Entrance
+  oarc: null
+  advancement: true
+- id: 269
+  name: Eldin Volcano Goddess Cube on Sand Slide
+  oarc: null
+  advancement: true
+- id: 270
+  name: Mogma Turf Goddess Cube
+  oarc: null
+  advancement: true
+- id: 271
+  name: Volcano Summit Goddess Cube in Lava Lake
+  oarc: null
+  advancement: true
+- id: 272
+  name: Volcano Summit Goddess Cube at Summit Waterfall
+  oarc: null
+  advancement: true
+- id: 273
+  name: Volcano Summit Goddess Cube near Fire Sanctuary Entrance
+  oarc: null
+  advancement: true
+- id: 274
+  name: Lanayru Mine Goddess Cube
+  oarc: null
+  advancement: true
+- id: 275
+  name: Lanayru Desert Goddess Cube near Caged Robot
+  oarc: null
+  advancement: true
+- id: 276
+  name: Lanayru Desert Goddess Cube in Sand Oasis
+  oarc: null
+  advancement: true
+- id: 277
+  name: Lanayru Desert Goddess Cube in Secret Passageway
+  oarc: null
+  advancement: true
+- id: 278
+  name: Lanayru Desert Goddess Cube near Temple of Time
+  oarc: null
+  advancement: true
+- id: 279
+  name: Lanayru Gorge Goddess Cube
+  oarc: null
+  advancement: true
+- id: 280
+  name: Ancient Harbour Goddess Cube
+  oarc: null
+  advancement: true
+- id: 281
+  name: Skipper's Retreat Goddess Cube
+  oarc: null
+  advancement: true
+- id: 282
+  name: Pirate Stronghold Goddess Cube
+  oarc: null
+  advancement: true
+- id: 283
+  name: Skyview Spring Goddess Cube
+  oarc: null
+  advancement: true

--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -906,29 +906,11 @@
   Paths:
     - stage/F100/r0/l0/Item/40
 
-- name: Deep Woods - Chest
-  original_item: Red Rupee
-  type:
-  Paths:
-    - stage/F101/r0/l0/TBox/74
-
-- name: Deep Woods - Gossip Stone
-  original_item: Nothing
-  type: Hint Location
-
 - name: Faron Woods - Chest behind Bombable Rocks near Erla
   original_item: Semi Rare Treasure
   type:
   Paths:
     - stage/F100/r0/l0/TBox/64
-
-- name: Great Tree - Chest
-  original_item: Gold Rupee
-  type:
-  Paths:
-    - stage/F100_1/r0/l0/TBox/84
-  hint: sometimes
-  text: climbing inside an <r<old hermit's home>> rewards
 
 - name: Faron Woods - Rupee on Great Tree North Branch
   original_item: Blue Rupee 
@@ -941,6 +923,48 @@
   type: Rupees (No Quick Beetle)
   Paths:
     - stage/F100/r0/l0/Item/44
+
+- name: Faron Woods - Goddess Cube on West Great Tree near Exit
+  original_item: Faron Woods Goddess Cube on West Great Tree near Exit
+  type: Goddess Cube
+
+- name: Faron Woods - Goddess Cube on East Great Tree with Clawshots Target
+  original_item: Faron Woods Goddess Cube on East Great Tree with Clawshots Target
+  type: Goddess Cube
+
+- name: Faron Woods - Goddess Cube on East Great Tree with Rope
+  original_item: Faron Woods Goddess Cube on East Great Tree with Rope
+  type: Goddess Cube
+
+- name: Great Tree - Chest
+  original_item: Gold Rupee
+  type:
+  Paths:
+    - stage/F100_1/r0/l0/TBox/84
+  hint: sometimes
+  text: climbing inside an <r<old hermit's home>> rewards
+
+- name: Deep Woods - Chest
+  original_item: Red Rupee
+  type:
+  Paths:
+    - stage/F101/r0/l0/TBox/74
+
+- name: Deep Woods - Gossip Stone
+  original_item: Nothing
+  type: Hint Location
+
+- name: Deep Woods - Goddess Cube Near Goron
+  original_item: Deep Woods Goddess Cube Near Goron
+  type: Goddess Cube
+
+- name: Deep Woods - Goddess Cube in front of Skyview
+  original_item: Deep Woods Goddess Cube in front of Skyview
+  type: Goddess Cube
+
+- name: Deep Woods - Goddess Cube on top of Skyview
+  original_item: Deep Woods Goddess Cube on top of Skyview
+  type: Goddess Cube
 
 # Lake Floria:
 
@@ -988,6 +1012,10 @@
   Paths:
     - stage/F102_2/r0/l0/TBox/85
 
+- name: Lake Floria - Goddess Cube
+  original_item: Lake Floria Goddess Cube
+  type: Goddess Cube
+
 - name: Floria Waterfall - Rupee on High Ledge
   original_item: Gold Rupee
   type: Rupees (No Quick Beetle)
@@ -997,6 +1025,10 @@
 - name: Floria Waterfall - Gossip Stone
   original_item: Nothing
   type: Hint Location
+
+- name: Floria Waterfall - Goddess Cube on High Ledge
+  original_item: Floria Waterfall Goddess Cube on High Ledge
+  type: Goddess Cube
 
 # Flooded Faron Woods:
 
@@ -1202,6 +1234,26 @@
   original_item: Nothing
   type: Hint Location
 
+- name: Eldin Volcano - Goddess Cube at Eldin Entrance
+  original_item: Eldin Volcano Goddess Cube at Eldin Entrance
+  type: Goddess Cube
+
+- name: Eldin Volcano - Goddess Cube near Mogma Turf Entrance
+  original_item: Eldin Volcano Goddess Cube near Mogma Turf Entrance
+  type: Goddess Cube
+
+- name: Eldin Volcano - Goddess Cube West of Earth Temple Entrance
+  original_item: Eldin Volcano Goddess Cube West of Earth Temple Entrance
+  type: Goddess Cube
+
+- name: Eldin Volcano - Goddess Cube East of Earth Temple Entrance
+  original_item: Eldin Volcano Goddess Cube East of Earth Temple Entrance
+  type: Goddess Cube
+
+- name: Eldin Volcano - Goddess Cube on Sand Slide
+  original_item: Eldin Volcano Goddess Cube on Sand Slide
+  type: Goddess Cube
+
 ## These checks are Digging Spots
 
 - name: Eldin Volcano - Digging Spot in front of Earth Temple
@@ -1272,6 +1324,10 @@
   Paths:
     - stage/F210/r0/l0/TBox/70
 
+- name: Mogma Turf - Goddess Cube
+  original_item: Mogma Turf Goddess Cube
+  type: Goddess Cube
+
 # Volcano Summit:
 
 - name: Volcano Summit - Chest behind Bombable Wall in Waterfall Area
@@ -1293,10 +1349,22 @@
   original_item: Nothing
   type: Hint Location
 
-
 - name: Volcano Summit - Gossip Stone near Second Thirsty Frog
   original_item: Nothing
   type: Hint Location
+
+- name: Volcano Summit - Goddess Cube in Lava Lake
+  original_item: Volcano Summit Goddess Cube in Lava Lake
+  type: Goddess Cube
+
+- name: Volcano Summit - Goddess Cube at Summit Waterfall
+  original_item: Volcano Summit Goddess Cube at Summit Waterfall
+  type: Goddess Cube
+
+- name: Volcano Summit - Goddess Cube near Fire Sanctuary Entrance
+  original_item: Volcano Summit Goddess Cube near Fire Sanctuary Entrance
+  type: Goddess Cube
+
 
 # Bokoblin Base:
 
@@ -1393,6 +1461,10 @@
   Paths:
     - stage/F300_1/r2/l0/TBox/66
 
+- name: Lanayru Mine - Goddess Cube
+  original_item: Lanayru Mine Goddess Cube
+  type: Goddess Cube
+
 # Lanayru Desert:
 
 - name: Lanayru Desert - Chest near Party Wheel
@@ -1451,6 +1523,22 @@
 - name: Temple of Time - Gossip Stone
   original_item: Nothing
   type: Hint Location
+
+- name: Lanayru Desert - Goddess Cube near Caged Robot
+  original_item: Lanayru Desert Goddess Cube near Caged Robot
+  type: Goddess Cube
+
+- name: Lanayru Desert - Goddess Cube in Sand Oasis
+  original_item: Lanayru Desert Goddess Cube in Sand Oasis
+  type: Goddess Cube
+
+- name: Lanayru Desert - Goddess Cube in Secret Passageway
+  original_item: Lanayru Desert Goddess Cube in Secret Passageway
+  type: Goddess Cube
+
+- name: Lanayru Desert - Goddess Cube near Temple of Time
+  original_item: Lanayru Desert Goddess Cube near Temple of Time
+  type: Goddess Cube
 
 ## Nodes
 
@@ -1552,6 +1640,10 @@
   Paths:
     - stage/F302/r0/l0/Soil/30
 
+- name: Lanayru Gorge - Goddess Cube
+  original_item: Lanayru Gorge Goddess Cube
+  type: Goddess Cube
+
 # Lanayru Sand Sea:
 ## Ancient Harbour
 
@@ -1572,6 +1664,10 @@
   type: Rupees (Quick Beetle)
   Paths:
     - stage/F301/r0/l0/Item/93
+
+- name: Ancient Harbour - Goddess Cube
+  original_item: Ancient Harbour Goddess Cube
+  type: Goddess Cube
 
 ## Skipper's Retreat
 
@@ -1601,6 +1697,10 @@
   type:
   Paths:
     - stage/F301_3/r0/l0/TBox/77
+
+- name: Skipper's Retreat - Goddess Cube
+  original_item: Skipper's Retreat Goddess Cube
+  type: Goddess Cube
 
 ## Shipyard
 
@@ -1637,6 +1737,10 @@
   Paths:
     - stage/F301_6/r0/l1/Item/13
     - stage/F301_6/r0/l2/Item/13
+
+- name: Pirate Stronghold - Goddess Cube
+  original_item: Pirate Stronghold Goddess Cube
+  type: Goddess Cube
 
 - name: Pirate Stronghold Interior - First Chest
   original_item: Silver Rupee
@@ -1752,6 +1856,10 @@
   Paths:
     - event/201-ForestD1/6
     - oarc/B100_1/l0
+
+- name: Skyview Spring - Goddess Cube
+  original_item: Skyview Spring Goddess Cube
+  type: Goddess Cube
 
 # Earth Temple (ET):
 

--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -1,14 +1,13 @@
 
 - name: Volcano Entrance
   hint_region: Eldin Volcano
-  events:
-    Goddess Cube at Eldin Entrance: Goddess_Sword
   exits:
     Volcano Entrance Statue: Nothing
     Volcano Ascent: Bomb_Bag or can_access(Volcano Ascent) # No bomb flowers are close enough for even tough beetle
     Volcano First Room: Nothing
   locations:
     Eldin Volcano - Rupee on Ledge before First Room: Nothing
+    Eldin Volcano - Goddess Cube at Eldin Entrance: Goddess_Sword
 
 
 - name: Volcano First Room # Until the rocks
@@ -23,8 +22,6 @@
 
 - name: Volcano East
   hint_region: Eldin Volcano
-  events:
-    Goddess Cube near Mogma Turf Entrance: Goddess_Sword
   exits:
     Volcano East Statue: Nothing
     Volcano Entrance: Clawshots
@@ -38,6 +35,7 @@
     Eldin Volcano - Item on Cliff: Nothing
     Eldin Volcano - Southeast Rupee above Mogma Turf Entrance: Beetle
     Eldin Volcano - North Rupee above Mogma Turf Entrance: Beetle
+    Eldin Volcano - Goddess Cube near Mogma Turf Entrance: Goddess_Sword
 
 
 - name: Past Mogma Turf
@@ -87,8 +85,6 @@
   hint_region: Eldin Volcano
   events:
     Retrieve Crystal Ball: Clawshots and Scrapper and 'Start_Sparrots_Quest'
-    Goddess Cube West of Earth Temple Entrance: Digging_Mitts and Goddess_Sword
-    Goddess Cube East of Earth Temple Entrance: Goddess_Sword
   exits:
     Temple Entrance Statue: Nothing
     Earth Temple First Room: open_earth_temple or count(5, Key_Piece)
@@ -99,6 +95,8 @@
     Eldin Volcano - Digging Spot below Tower: Digging_Mitts
     Eldin Volcano - Digging Spot behind Boulder on Sandy Slope: Digging_Mitts
     Eldin Volcano - Gossip Stone next to Earth Temple: Digging_Mitts
+    Eldin Volcano - Goddess Cube West of Earth Temple Entrance: Digging_Mitts and Goddess_Sword
+    Eldin Volcano - Goddess Cube East of Earth Temple Entrance: Goddess_Sword
   
 
 - name: Outside Upper Eldin Cave
@@ -126,12 +124,11 @@
 
 - name: Sand Slide
   hint_region: Eldin Volcano
-  events:
-    Goddess Cube on Sand Slide: Goddess_Sword
   exits:
     Past Sand Slide: Nothing
   locations:
     Eldin Volcano - Digging Spot after Vents: Digging_Mitts
+    Eldin Volcano - Goddess Cube on Sand Slide: Goddess_Sword
 
 - name: Past Sand Slide
   hint_region: Eldin Volcano
@@ -163,12 +160,12 @@
 - name: Mogma Turf Dive
   hint_region: Mogma Turf
   events:
-    Goddess Cube in Mogma Turf: Goddess_Sword
     Pick up Guld: Scrapper and 'Start_Kinas_Quest'
   exits:
     Mogma Turf: Nothing
   locations:
     Mogma Turf - Free Fall Chest: Nothing
+    Mogma Turf - Goddess Cube: Goddess_Sword
 
 
 - name: Mogma Turf
@@ -216,24 +213,24 @@
 # VOLCANO SUMMIT
 - name: Volcano Summit
   hint_region: Volcano Summit
-  events:
-    Goddess Cube inside Volcano Summit: (Fireshield_Earrings and Long_Range_Skyward_Strike) or 'Beaten_Boko_Base'
   exits:
     Hot Cave: Fireshield_Earrings
     Volcano Summit Waterfall: Fireshield_Earrings
     Past Volcano Summit: Fireshield_Earrings
+  locations:
+    Volcano Summit - Goddess Cube in Lava Lake: (Fireshield_Earrings and Long_Range_Skyward_Strike) or 'Beaten_Boko_Base'
     
 
 - name: Volcano Summit Waterfall
   hint_region: Volcano Summit
   events:
     Can Collect Water: Bottle
-    Goddess Cube in Summit Waterfall: Goddess_Sword # Bomb flower for death warp without claws
   exits:
     Volcano Summit: Nothing
   locations:
     Volcano Summit - Chest behind Bombable Wall in Waterfall Area: Clawshots
     Volcano Summit - Gossip Stone in Waterfall Area: Clawshots
+    Volcano Summit - Goddess Cube at Summit Waterfall: Goddess_Sword # Bomb flower for death warp without claws
 
 
 - name: Past Volcano Summit
@@ -246,12 +243,12 @@
 
 
 - name: Outside Fire Sanctuary
-  events:
-    Goddess Cube near Fire Sanctuary Entrance: Clawshots and Goddess_Sword
   exits:
     Inside the Volcano Statue: Nothing
     Fire Sanctuary First Room: Nothing
     Past Volcano Summit: can_access(Past Volcano Summit) and Clawshots and 'Can_Collect_Water'
+  locations:
+    Volcano Summit - Goddess Cube near Fire Sanctuary Entrance: Clawshots and Goddess_Sword
 
  # BOKOBLIN BASE
 - name: Bokoblin Base Prison

--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -146,24 +146,24 @@
 
 - name: Great Tree West Branch
   hint_region: Faron Woods
-  events:
-    Goddess Cube on West Great Tree near Exit: Goddess_Sword
+  locations:
+    Faron Woods - Goddess Cube on West Great Tree near Exit: Goddess_Sword
   exits:
     Faron Woods: Nothing
     
 
 - name: Great Tree Clawshot Target Branch
   hint_region: Faron Woods
-  events:
-    Goddess Cube on East Great Tree with Clawshots Target: Goddess_Sword
+  locations:
+    Faron Woods - Goddess Cube on East Great Tree with Clawshots Target: Goddess_Sword
   exits:
     Faron Woods: Nothing
     
 
 - name: Great Tree Rope Branch
   hint_region: Faron Woods
-  events:
-    Goddess Cube on East Great Tree with Rope: Goddess_Sword
+  locations:
+    Faron Woods - Goddess Cube on East Great Tree with Rope: Goddess_Sword
   exits:
     Faron Woods: Nothing
 
@@ -243,9 +243,6 @@
   hint_region: Faron Woods
   events:
     Push Down Deep Woods Shortcut Logs: Nothing
-    Initial Goddess Cube: Goddess_Sword
-    Goddess Cube in Deep Woods: Goddess_Sword
-    Goddess Cube on top of Skyview: Goddess_Sword and Clawshots
   exits:
     Deep Woods Statue: Nothing
     Forest Temple Statue: Nothing
@@ -253,6 +250,9 @@
   locations:
     Deep Woods - Chest: Nothing
     Deep Woods - Gossip Stone: Nothing
+    Deep Woods - Goddess Cube Near Goron: Goddess_Sword
+    Deep Woods - Goddess Cube in front of Skyview: Goddess_Sword
+    Deep Woods - Goddess Cube on top of Skyview: Goddess_Sword and Clawshots
 
 
 - name: Faron Silent Realm
@@ -327,13 +327,12 @@
 
 - name: Lake Floria Emerged Area
   hint_region: Lake Floria
-  events:
-    Goddess Cube in Lake Floria: Goddess_Sword
   exits:
     Lake Floria Statue: Nothing
     Lake Floria: Water_Dragons_Scale
   locations:
     Lake Floria - Chest: Nothing
+    Lake Floria - Goddess Cube: Goddess_Sword
 
 
 - name: Farore's Lair
@@ -351,7 +350,6 @@
 - name: Floria Waterfall
   hint_region: Lake Floria
   events:
-    Goddess Cube in Floria Waterfall: Clawshots and Goddess_Sword
     Can Collect Water: Bottle
   exits:
     Floria Waterfall Statue: Nothing
@@ -361,6 +359,7 @@
   locations:
     Floria Waterfall - Gossip Stone: Nothing
     Floria Waterfall - Rupee on High Ledge: Beetle
+    Floria Waterfall - Goddess Cube on High Ledge: Clawshots and Goddess_Sword
 
 
 - name: Floria Waterfall Temple Ledge

--- a/data/world/Lanayru.yaml
+++ b/data/world/Lanayru.yaml
@@ -3,7 +3,6 @@
 - name: Lanayru Mine Entry
   hint_region: Lanayru Mine
   events:
-    Goddess Cube at Lanayru Mine Entrance: Goddess_Sword
     Lanayru Mine First Timeshift Stone: Can_Hit_Timeshift_Stone or logic_itemless_first_timeshift_stone
     Ancient Flower Farming: "'Lanayru_Mine_First_Timeshift_Stone'"
     Blow Down First Mine Statue: Nothing
@@ -13,6 +12,7 @@
     Lanayru Mine Upper Area: Clawshots
   locations:
     Lanayru Mine - Chest near First Timeshift Stone: "'Lanayru_Mine_First_Timeshift_Stone'"
+    Lanayru Mine - Goddess Cube: Goddess_Sword
 
 
 - name: Lanayru Mine Upper Area
@@ -66,7 +66,6 @@
   events:
     Retrieve Party Wheel: Scrapper and 'Start_Dodohs_Quest'
     Ancient Flower Farming: Blow_Up_Covered_Timeshift_Stone
-    Goddess Cube near Rescue Caged Robot: Long_Range_Skyward_Strike # Also accessible elsewhere
 
     # Hook Beetle to knock down statue platforms
     # Stamina Potion to run past the Spume
@@ -88,22 +87,22 @@
     # You can use the bomb flowers to *just* throw one up into the hole in the cage from the ground
     # This trick is only doable on HD
     Lanayru Desert - Rescue Caged Robot: (Blow_Up_Covered_Timeshift_Stone or Hook_Beetle or logic_bomb_throws) and Can_Defeat_Bokoblins
+    Lanayru Desert - Goddess Cube near Caged Robot: Long_Range_Skyward_Strike # Also accessible elsewhere
 
 
 - name: Lanayru Desert West Courtyard
   hint_region: Lanayru Desert
-  events:
-    Goddess Cube in Sand Oasis: Can_Navigate_in_Oasis and Goddess_Sword
   exits:
     Lanayru Desert South: Nothing
     Lanayru Desert West Wall: Clawshots or 'Push_Down_West_Wall_Minecart'
     Sand Oasis Middle: Can_Navigate_in_Oasis or 'Push_Down_First_Sand_Oasis_Minecart'
+  locations:
+    Lanayru Desert - Goddess Cube in Sand Oasis: Can_Navigate_in_Oasis and Goddess_Sword
 
 
 - name: Lanayru Desert West Wall
   hint_region: Lanayru Desert
   events:
-    Goddess Cube near Rescue Caged Robot: Goddess_Sword
     Push Down West Wall Minecart: Nothing
   exits:
     Lanayru Desert South: Nothing
@@ -111,18 +110,20 @@
     Lanayru Desert North: Nothing
   locations:
     Lanayru Desert - Chest near Sand Oasis: Nothing
+    Lanayru Desert - Goddess Cube near Caged Robot: Goddess_Sword
 
 
 - name: Sand Oasis Middle
   hint_region: Lanayru Desert
   events:
-    Goddess Cube in Sand Oasis: Goddess_Sword
     Push Down First Sand Oasis Minecart: Nothing
   exits:
     West Desert Statue: Nothing
     Lanayru Desert West Courtyard: Nothing
     Lanayru Desert West Wall: Clawshots
     Sand Oasis End: Can_Navigate_in_Oasis or Clawshots or 'Push_Down_Second_Sand_Oasis_Minecart'
+  locations:
+    Lanayru Desert - Goddess Cube in Sand Oasis: Goddess_Sword
 
 
 - name: Sand Oasis End
@@ -185,12 +186,11 @@
 
 - name: Lanayru Desert Secret Passageway
   hint_region: Lanayru Desert
-  events:
-    Goddess Cube in Secret Passageway: Clawshots and Goddess_Sword
   exits:
     Lanayru Desert North: Nothing
   locations:
     Lanayru Desert - Secret Passageway Chest: Nothing
+    Lanayru Desert - Goddess Cube in Secret Passageway: Clawshots and Goddess_Sword
 
 
 - name: Lanayru Desert East
@@ -252,10 +252,10 @@
 
 - name: Temple of Time North Minecart Ride
   hint_region: Lanayru Desert
-  events:
-    Goddess Cube at Ride near Temple of Time: Goddess_Sword
   exits:
     Temple of Time North: Nothing
+  locations:
+    Lanayru Desert - Goddess Cube near Temple of Time: Goddess_Sword
     
 
 - name: Temple of Time North
@@ -320,12 +320,12 @@
 - name: Lanayru Gorge Beyond Bridge
   hint_region: Lanayru Gorge
   events:
-    Goddess Cube in Lanayru Gorge: Goddess_Sword
     Ancient Flower Farming: Gust_Bellows and Can_Hit_Timeshift_Stone
   exits:
     Lanayru Gorge: Beetle or Bow # To activate the main Timeshift Stone
   locations:
     Lanayru Gorge - Digging Spot: Gust_Bellows and Can_Hit_Timeshift_Stone and Digging_Mitts
+    Lanayru Gorge - Goddess Cube: Goddess_Sword
 
 
 - name: Ancient Harbour Highest Platform
@@ -341,13 +341,13 @@
 
 - name: Ancient Harbour
   hint_region: Lanayru Sand Sea
-  events:
-    Goddess Cube in Ancient Harbour: Clawshots and Goddess_Sword
   exits:
     Lanayru Sand Sea: Distance_Activator or Sword or Bomb_Bag
     # Sandship Main Deck: (Distance_Activator or Sword or Bomb_Bag) and 'Shoot_down_Sandship'
     Ancient Harbour Statue: Nothing
     Ancient Harbour Highest Platform: Clawshots
+  locations:
+    Ancient Harbour - Goddess Cube: Clawshots and Goddess_Sword
   
 
 - name: Lanayru Sand Sea
@@ -372,13 +372,12 @@
 
 - name: Skipper's Retreat Past Rock
   hint_region: Lanayru Sand Sea
-  events:
-    Goddess Cube in Skippers Retreat: Clawshots and Goddess_Sword
   exits:
     Skipper's Retreat Top: Clawshots and Whip and (Projectile_Item or logic_skippers_fast_clawshots)
     Skipper's Retreat Dock: Nothing
   locations:
     Skipper's Retreat - Chest after Moblin: Nothing
+    Skipper's Retreat - Goddess Cube: Clawshots and Goddess_Sword
 
 
 - name: Skipper's Retreat Top
@@ -452,8 +451,6 @@
 # "'Finish_Pirate_Stronghold'" means the Shark Head is raised
 - name: Pirate Stronghold Inside the Shark Head
   hint_region: Lanayru Sand Sea
-  events:
-    Goddess Cube in Pirate Stronghold: Clawshots and Goddess_Sword
   exits:
     # Clawshot up and run along the Shark Head or just run out if it's been raised
     Pirate Stronghold Dock: Clawshots or 'Finish_Pirate_Stronghold'
@@ -463,6 +460,7 @@
     Pirate Stronghold - Rupee on West Sea Pillar: Quick_Beetle
     Pirate Stronghold - Rupee on East Sea Pillar: Quick_Beetle
     Pirate Stronghold - Rupee on Bird Statue Pillar or Nose: Beetle # Still possible
+    Pirate Stronghold - Goddess Cube: Clawshots and Goddess_Sword
     
 
 - name: Pirate Stronghold Interior

--- a/data/world/Sky.yaml
+++ b/data/world/Sky.yaml
@@ -76,7 +76,7 @@
     Bamboo Island Interior: Day
     The Sky: Day
   locations:
-    Bamboo Island - Goddess Chest: "'Goddess_Cube_West_of_Earth_Temple_Entrance'"
+    Bamboo Island - Goddess Chest: Eldin_Volcano_Goddess_Cube_West_of_Earth_Temple_Entrance
 
 
 - name: Bamboo Island Interior
@@ -95,8 +95,8 @@
   exits:
     The Sky: Day
   locations:
-    Island near Bamboo Island - Goddess Chest: "'Goddess_Cube_near_Mogma_Turf_Entrance'"
-    Island near Bamboo Island - Goddess Chest in Cave: Water_Dragons_Scale and 'Goddess_Cube_near_Mogma_Turf_Entrance'
+    Island near Bamboo Island - Goddess Chest: Eldin_Volcano_Goddess_Cube_near_Mogma_Turf_Entrance
+    Island near Bamboo Island - Goddess Chest in Cave: Water_Dragons_Scale and Lanayru_Desert_Goddess_Cube_in_Secret_Passageway
 
 
 - name: Beedle's Island
@@ -107,8 +107,8 @@
   locations:
     Beedle's Island - Crystal: Night and Beetle
     Beedle's Island - Beedle's Crystals: Night and Beedles_Insect_Cage
-    Beedle's Island - Top Goddess Chest: Day and 'Goddess_Cube_at_Ride_near_Temple_of_Time'
-    Beedle's Island - Cage Goddess Chest: (Night or (Day and logic_beedles_island_cage_chest_dive)) and 'Goddess_Cube_on_top_of_Skyview'
+    Beedle's Island - Top Goddess Chest: Day and Lanayru_Desert_Goddess_Cube_near_Temple_of_Time
+    Beedle's Island - Cage Goddess Chest: (Night or (Day and logic_beedles_island_cage_chest_dive)) and Deep_Woods_Goddess_Cube_on_top_of_Skyview
 
 
 - name: Northeast Island
@@ -116,8 +116,8 @@
   exits:
     The Sky: Day
   locations:
-    Northeast Island - Goddess Chest behind Bombable Rocks: Bomb_Bag and 'Goddess_Cube_at_Lanayru_Mine_Entrance'
-    Northeast Island - Cage Goddess Chest: "'Goddess_Cube_East_of_Earth_Temple_Entrance'"
+    Northeast Island - Goddess Chest behind Bombable Rocks: Bomb_Bag and Lanayru_Mine_Goddess_Cube
+    Northeast Island - Cage Goddess Chest: Eldin_Volcano_Goddess_Cube_East_of_Earth_Temple_Entrance
 
 
 - name: Lumpy Pumpkin Exterior
@@ -132,8 +132,8 @@
     The Sky: Day
   locations:
     Lumpy Pumpkin - Outside Crystal: Night
-    Lumpy Pumpkin - Outside Goddess Chest: "'Initial_Goddess_Cube'"
-    Lumpy Pumpkin - Goddess Chest on Roof: Day and 'Goddess_Cube_in_Skyview_Spring'
+    Lumpy Pumpkin - Outside Goddess Chest: Deep_Woods_Goddess_Cube_Near_Goron
+    Lumpy Pumpkin - Goddess Chest on Roof: Day and Skyview_Spring_Goddess_Cube
     Lumpy Pumpkin - Kina's Crystals: Day and 'Pick_up_Guld'
     Lumpy Pumpkin - Gossip Stone: Nothing
 
@@ -175,7 +175,7 @@
   exits:
     The Sky: Day
   locations:
-    Island Closest to Faron Pillar - Goddess Chest: "'Goddess_Cube_in_Deep_Woods'"
+    Island Closest to Faron Pillar - Goddess Chest: Deep_Woods_Goddess_Cube_in_front_of_Skyview
 
 
 - name: Volcanic Island
@@ -185,8 +185,8 @@
   exits:
     The Sky: Day
   locations:
-    Volcanic Island - Outside Goddess Chest: "'Goddess_Cube_in_Sand_Oasis'"
-    Volcanic Island - Inside Goddess Chest: (Clawshots or logic_volcanic_island_dive) and 'Goddess_Cube_on_East_Great_Tree_with_Clawshots_Target'
+    Volcanic Island - Outside Goddess Chest: Lanayru_Desert_Goddess_Cube_in_Sand_Oasis
+    Volcanic Island - Inside Goddess Chest: (Clawshots or logic_volcanic_island_dive) and Faron_Woods_Goddess_Cube_on_East_Great_Tree_with_Clawshots_Target
     Volcanic Island - Gossip Stone: Nothing
 
 
@@ -211,7 +211,7 @@
   locations:
     Fun Fun Island - Dodoh's Crystals: "'Retrieve_Party_Wheel'"
     Fun Fun Island - Minigame -- 500 Rupees: "'Can_Play_Fun_Fun_Island_Minigame'"
-    Fun Fun Island - Goddess Chest: Day and 'Goddess_Cube_in_Floria_Waterfall'
+    Fun Fun Island - Goddess Chest: Day and Floria_Waterfall_Goddess_Cube_on_High_Ledge
 
 
 - name: Triple Island
@@ -219,9 +219,9 @@
   exits:
     The Sky: Day
   locations:
-    Triple Island - Upper Goddess Chest: "'Goddess_Cube_at_Eldin_Entrance'"
-    Triple Island - Lower Goddess Chest: "'Goddess_Cube_near_Rescue_Caged_Robot'"
-    Triple Island - Cage Goddess Chest: Clawshots and 'Goddess_Cube_in_Skippers_Retreat'
+    Triple Island - Upper Goddess Chest: Eldin_Volcano_Goddess_Cube_at_Eldin_Entrance
+    Triple Island - Lower Goddess Chest: Lanayru_Desert_Goddess_Cube_near_Caged_Robot
+    Triple Island - Cage Goddess Chest: Clawshots and Skippers_Retreat_Goddess_Cube
 
 # TODO: Check day/night stuff
 - name: The Thunderhead
@@ -243,8 +243,8 @@
     The Thunderhead: Day
     Isle of Songs Interior: Sword
   locations:
-    Isle of Songs - Top Goddess Chest: Day and 'Goddess_Cube_near_Fire_Sanctuary_Entrance'
-    Isle of Songs - Lower Goddess Chest: Day and 'Goddess_Cube_in_Mogma_Turf' 
+    Isle of Songs - Top Goddess Chest: Day and Volcano_Summit_Goddess_Cube_near_Fire_Sanctuary_Entrance
+    Isle of Songs - Lower Goddess Chest: Day and Mogma_Turf_Goddess_Cube
 
 
 - name: Isle of Songs Interior
@@ -261,7 +261,7 @@
   exits:
     The Thunderhead: Day
   locations:
-    Thunderhead East Island - Goddess Chest: "'Goddess_Cube_on_East_Great_Tree_with_Rope'"
+    Thunderhead East Island - Goddess Chest: Faron_Woods_Goddess_Cube_on_East_Great_Tree_with_Rope
     Thunderhead East Island - Chest: Digging_Mitts or logic_east_island_dive
 
 
@@ -270,8 +270,8 @@
   exits:
     The Thunderhead: Day
   locations:
-    Mogma Mitts Island - First Goddess Chest: Mogma_Mitts and 'Goddess_Cube_inside_Volcano_Summit'
-    Mogma Mitts Island - Second Goddess Chest: Mogma_Mitts and 'Goddess_Cube_in_Lanayru_Gorge'
+    Mogma Mitts Island - First Goddess Chest: Mogma_Mitts and Volcano_Summit_Goddess_Cube_in_Lava_Lake
+    Mogma Mitts Island - Second Goddess Chest: Mogma_Mitts and Lanayru_Gorge_Goddess_Cube
 
 
 - name: Bug Heaven
@@ -282,5 +282,5 @@
     The Thunderhead: Day
   locations:
     Bug Heaven - Minigame -- 10 Bugs in 3 Minutes: Bug_Net
-    Bug Heaven - Goddess Chest: "'Goddess_Cube_in_Summit_Waterfall'"
+    Bug Heaven - Goddess Chest: Volcano_Summit_Goddess_Cube_at_Summit_Waterfall
     Bug Heaven - Nearby Gossip Stone: Nothing

--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -161,11 +161,11 @@
     Central Skyloft - Crystal between Wooden Planks: Night
     Central Skyloft - Crystal on West Cliff: Night
     Central Skyloft - Crystal on Light Tower: Night
-    Central Skyloft - West Cliff Goddess Chest: "'Goddess_Cube_on_West_Great_Tree_near_Exit'"
+    Central Skyloft - West Cliff Goddess Chest: Faron_Woods_Goddess_Cube_on_West_Great_Tree_near_Exit
     Central Skyloft - Parrow's Gift: Day and 'Talk_to_Orielle'
     Central Skyloft - Parrow's Crystals: Day and 'Save_Orielle'
     Central Skyloft - Shed Chest: Water_Dragons_Scale
-    Central Skyloft - Shed Goddess Chest: Water_Dragons_Scale and 'Goddess_Cube_on_Sand_Slide'
+    Central Skyloft - Shed Goddess Chest: Water_Dragons_Scale and Eldin_Volcano_Goddess_Cube_on_Sand_Slide
     Central Skyloft - Crystal on Waterfall Island: Night and Quick_Beetle and logic_precise_beetle
     Central Skyloft - Crystal after Waterfall Cave: Night and Beetle and logic_precise_beetle
     Central Skyloft - Crystal in Loftwing Prison: Night and Beetle and logic_precise_beetle
@@ -190,7 +190,7 @@
     Bazaar South: Nothing
   locations:
     Bazaar - Potion Lady's Gift: Nothing
-    Bazaar - Goddess Chest: "'Goddess_Cube_in_Ancient_Harbour'"
+    Bazaar - Goddess Chest: Ancient_Harbour_Goddess_Cube
     # Bazaar - Upgrade to Quick Beetle: Hook_Beetle and 'Hornet_Larvae_Farming' and 'Ancient_Flower_Farming' and 'Can_Play_Clean_Cut_Minigame' # Golden Skull farming
     # Bazaar - Upgrade to Tough Beetle: Quick_Beetle and 'Hornet_Larvae_Farming' and 'Ancient_Flower_Farming' and 'Can_Play_Clean_Cut_Minigame' # Golden Skull farming
     # Bazaar - Upgrade to Scattershot: Slingshot and 'Can_Play_Clean_Cut_Minigame'
@@ -278,8 +278,8 @@
     Bird Nest: Nothing
   locations:
     Central Skyloft - Crystal on Waterfall Island: Night
-    Central Skyloft - Waterfall Goddess Chest: "'Goddess_Cube_in_Pirate_Stronghold'"
-    Central Skyloft - Floating Island Goddess Chest: "'Goddess_Cube_in_Lake_Floria'"
+    Central Skyloft - Waterfall Goddess Chest: Pirate_Stronghold_Goddess_Cube
+    Central Skyloft - Floating Island Goddess Chest: Lake_Floria_Goddess_Cube
     Central Skyloft - Gossip Stone on Waterfall Island: Nothing
 
 

--- a/data/world/Skyview.yaml
+++ b/data/world/Skyview.yaml
@@ -158,7 +158,6 @@
 
 - name: Skyview Spring
   events:
-    Goddess Cube in Skyview Spring: Goddess_Sword
     Can Collect Water: Bottle
     Sacred Water: Bottle and Skyview_2
   exits:
@@ -167,3 +166,4 @@
   locations:
     Skyview Spring - Rupee on Spring Pillar: Beetle
     Skyview Spring - Strike Crest: Goddess_Sword
+    Skyview Spring - Goddess Cube: Goddess_Sword

--- a/logic/spoiler_log.py
+++ b/logic/spoiler_log.py
@@ -4,6 +4,8 @@ from .entrance_shuffle import create_entrance_pools
 
 def spoiler_format_location(location: Location, longest_name_length: int) -> str:
     spaces = longest_name_length - len(f"{location}")
+    if "Goddess Cube" in location.types:
+        return f"{location}"
     return f"{location}: {spaces * ' '}{location.current_item}"
 
 
@@ -79,14 +81,19 @@ def generate_spoiler_log(worlds: list[World]) -> None:
                 )
 
         # Recalculate longest name length for all locations
+        longest_name_length = 0
         for location in worlds[0].location_table.values():
-            longest_name_length = max(longest_name_length, len(f"{location}"))
+            if "Goddess Cube" not in location.types:
+                longest_name_length = max(longest_name_length, len(f"{location}"))
 
         spoiler_log.write("\nAll Locations:\n")
         for world in worlds:
             spoiler_log.write(f"    {world}:\n")
             for location in world.location_table.values():
-                if "Hint Location" not in location.types:
+                if (
+                    "Hint Location" not in location.types
+                    and "Goddess Cube" not in location.types
+                ):
                     spoiler_log.write(
                         "        "
                         + spoiler_format_location(location, longest_name_length)
@@ -94,6 +101,7 @@ def generate_spoiler_log(worlds: list[World]) -> None:
                     )
 
         # Recalculate longest name length for all shuffled entrances
+        longest_name_length = 0
         for world in worlds:
             for entrance in world.get_shuffled_entrances():
                 longest_name_length = max(longest_name_length, len(f"{entrance}"))

--- a/logic/world.py
+++ b/logic/world.py
@@ -364,6 +364,10 @@ class World:
                 else:
                     location.set_current_item(self.get_item("Green Rupee"))
 
+            # Set Goddess Cubes as having their own item
+            if "Goddess Cube" in location.types:
+                location.set_current_item(item)
+
     def perform_post_entrance_shuffle_tasks(self) -> None:
         self.assign_all_areas_hint_regions()
         self.choose_required_dungeons()


### PR DESCRIPTION
## What does this PR do?
All goddess cube events have been changed to locations which hold their default goddess cube "items". These are just dummy items meant to represent activating the respective goddess cube. This allows goddess cubes to appear in the spoiler log playthrough and will allow players to mark off which goddess cubes they hit in the tracker without needing any special handling.

## How do you test this changes?
I generated a bunch of seeds and ran all the logic tests to ensure that everything looked good

## Notes
This would need to happen in the future anyway if we were to ever implement some sort of "goddess-cube-sanity" option. So I figured we could get it out of the way now.
