### PR TITLE
Fix pirate nose rupee

### DIFF
--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -1735,7 +1735,9 @@
   original_item: Silver Rupee 
   type: Rupees (No Quick Beetle)
   Paths:
-    - stage/F301_6/r0/l0/Item/13
+    - stage/F301_6/r0/l1/Item/13
+    - stage/F301_6/r0/l2/Item/13
+    - oarc/F301_6/l0
 
 - name: Pirate Stronghold - Goddess Cube
   original_item: Pirate Stronghold Goddess Cube


### PR DESCRIPTION
## What does this PR do?
Fixes a bug where the rupee in the shark head nose, outside Pirate Stronghold stage (F301_6), could sometimes not appear on the bird statue pillar when the shark head is raised. This is due to layer 1 (shark head raised) not having any other objects defined in the bzs file so patching the model onto l1 fails.

For now, I've made it patch the model onto layer 0. Hopefully the underlying issue can be fixed when it's looked into but it's not too urgent for now

## How do you test this changes?
Applied this fix onto the seed I've been play-testing and was able to get the check I was unable to get before the fix