### PR TITLE
Fix the Goddess Statue (again)

### DIFF
--- a/data/entrance_shuffle_data.yaml
+++ b/data/entrance_shuffle_data.yaml
@@ -1022,7 +1022,7 @@
         index: 5
     spawn_info:
       - stage: F008r
-        layer: 1
+        layer: 0
         room: 0
         entrance: 0
   return:  

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -1105,11 +1105,11 @@ F008r: # Goddess Statue
     override:
       - story_flag: -1
         night: 2
-        layer: 1
+        layer: 0
   - name: Fi text after pulling Goddess Sword
     type: objadd
     room: 0
-    layer: 1
+    layer: 0
     id: 0xFC00
     objtype: OBJ
     object:
@@ -1124,19 +1124,6 @@ F008r: # Goddess Statue
       name: NpcTke
       trigstoryfid: 951 # Raised Goddess Sword in Goddess Statue
       untrigscenefid: 25 # Scene flag 25 - Skyward Strike on Tablet Pedestal (unused in rando)
-  - name: Move Sword Pedestal to l1
-    type: objmove
-    id: 0xFC05
-    layer: 0
-    destlayer: 1
-    room: 0
-    objtype: OBJ
-  - name: Remove cutscene trigger on l1
-    type: objdelete
-    id: 0xFC0E
-    layer: 1
-    room: 0
-    objtype: STAG
   - name: Delete Crest
     type: objdelete
     id: 0xFC02


### PR DESCRIPTION
## What does this PR do?
Force the Goddess Statue stage to always be on layer 0

## How do you test this changes?
Entered the Goddess Statue before the fix and it was on layer 0 (previously we expected layer 1). I've moved everything to layer 0 (since it doesn't matter) and changed the entrance data to reflect this change (still not sure why forcing it to layer 1 didn't work tho - layeroverrides are very picky)