### PR TITLE
Retype excluded_locations from set to list

### DIFF
--- a/logic/config.py
+++ b/logic/config.py
@@ -40,7 +40,7 @@ def create_default_config(filename: str):
     conf.settings.append(SettingMap())
     setting_map = conf.settings[0]
     setting_map.starting_inventory = Counter()
-    setting_map.excluded_locations = set()
+    setting_map.excluded_locations = []
     setting_map.mixed_entrance_pools = []
 
     for setting_name, setting_info in get_all_settings_info().items():
@@ -129,8 +129,10 @@ def load_config_from_file(filename: str, allow_rewrite: bool = True) -> Config:
 
                 # Special handling for excluded locations
                 if setting_name == "excluded_locations":
-                    excluded_locations = config_in[world_num_str][setting_name]
-                    cur_world_settings.excluded_locations = set(excluded_locations)
+                    excluded_locations: list[str] = config_in[world_num_str][
+                        setting_name
+                    ]
+                    cur_world_settings.excluded_locations = excluded_locations
                     continue
 
                 # Special handling for mixed entrance pools

--- a/logic/settings.py
+++ b/logic/settings.py
@@ -84,7 +84,7 @@ class SettingMap:
     def __init__(self) -> None:
         self.settings: OrderedDict[str, Setting] = {}
         self.starting_inventory: Counter[str] = Counter()
-        self.excluded_locations: set = set()
+        self.excluded_locations: list[str] = []
         self.mixed_entrance_pools: list[list[str]] = []
 
 

--- a/logic/spoiler_log.py
+++ b/logic/spoiler_log.py
@@ -187,7 +187,7 @@ def generate_spoiler_log(worlds: list[World]) -> None:
                 f"    starting_inventory: {sorted(world.setting_map.starting_inventory.elements())}\n"
             )
             spoiler_log.write(
-                f"    excluded_locations: {list(world.setting_map.excluded_locations)}\n"
+                f"    excluded_locations: {world.setting_map.excluded_locations}\n"
             )
             spoiler_log.write(
                 f"    mixed_entrance_pools: {world.setting_map.mixed_entrance_pools}\n"


### PR DESCRIPTION
## What does this PR do?
Fixes an issue with the `spoiler_as_config` test where it expects the spoiler log to be generated the exact same way each time. `excluded_locations` was previously stored as a set which meant that the order locations were written to the spoiler log wasn't consistent and would sometimes cause the test to fail

## How do you test this changes?
Ran `pytest` 5 times and it seems okay now
