### PR TITLE
Fix More Items than Locations Warning

### DIFF
--- a/logic/world.py
+++ b/logic/world.py
@@ -504,7 +504,6 @@ class World:
     # Remove or add junk to the item pool until the total number of
     # items is equal to the number of currently empty locations
     def sanitize_item_pool(self) -> None:
-        
         # Get rid of any negative item counts. This can happen if
         # a user plandomizes an item into more locations than the
         # number of times the item appears in the pool


### PR DESCRIPTION
## What does this PR do?
Fixes the item pool so we don't get the warning about there being more items than locations when placing the junk items. This was caused by there being negative counts for some items in the case where said items were being plandomized into more locations than they would appear in the item pool. 

## How do you test this changes?
The warning went away on the 2 seeds that I had which would always throw the warning. I manually checked the item and location counts and they match up now.
