### PR TITLE
Remove PlRsTags from boko base

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -2866,6 +2866,12 @@ F202: # Bokoblin Base
       sizey: 2000
       sizez: 2000
       angle: 0
+  - name: Remove PlRsTags
+    type: objdelete
+    startid: 0xFC0D
+    endid: 0xFC13
+    layer: 1
+    objtype: STAG
   - name: Add ammo pot to Volcano Entry Bird Statue # Can't get to this one
     onlyif: ammo_availability == plentiful
     type: objadd


### PR DESCRIPTION
## What does this PR do?
Removes the PlayerReset Tags from boko base. This was necessary in SDR to allow you to deathwarp after getting the vanilla slingshot chest (since you need claws to get back out). I couldn't replicate the issue on HD but removing them just to be safe.

In SDR, they keep 1 PlRsTag and modify it so that it doesn't reset your inventory. They do this as PlRsTags also happen to prevent you from activating BiT. Since HD doesn't have BiT, there's no need to keep a PlRsTag around - so I've just removed them all