### PR TITLE
Fix stamina fruit location type typo

### DIFF
--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -733,7 +733,7 @@
     - stage/F000/r0/l7/Item/108
     - stage/F000/r0/l9/Item/108
 
-- name: Skyloft Village - Stamina Fruits
+- name: Skyloft Village - Stamina Fruit
   original_item: Stamina Fruit
   types:
     - Stamina Fruits
@@ -1762,7 +1762,7 @@
   Paths:
     - stage/F101/r0/l0/TBox/74
 
-- name: Deep Woods - Stamina Fruits
+- name: Deep Woods - Stamina Fruit
   original_item: Stamina Fruit
   types:
     - Stamina Fruits


### PR DESCRIPTION
## What does this PR do?
Fix a typo in the stamina fruit location type that was causing silent realm stamina fruits to be randomized even with stamina fruit shuffle turned off.

## How do you test this changes?
Genned a seed with stamina fruit shuffle turned off and the silent realm stamina fruit checks no longer show up in the spoiler log :p