### PR TITLE
Fix Thunder Dragon text

### DIFF
--- a/data/text_data/english.yaml
+++ b/data/text_data/english.yaml
@@ -213,7 +213,7 @@
   standard: "You can't beat this\ndungeon at the present\ntime, I would suggest\ncoming back later"
 
 - name: Thunderdragon Thank you text
-  standard: "Thank you for saving me"
+  standard: "Thank you for saving me."
 
 - name: botg context text
   standard: "I see you have acquired the <y<harp>>.\nWell done. Let me teach you a <b<song>>,\nit will be useful for your adventure."


### PR DESCRIPTION
## What does this PR do?
Adds a missing full stop to the end of the Thunder Dragon's text.