### PR TITLE
Make FS Big Frog look watered

### DIFF
--- a/data/patches/startflags.yaml
+++ b/data/patches/startflags.yaml
@@ -16,6 +16,7 @@ Storyflags:
   - 130  # Start with Beacon
   - 138  # Sealed Temple layer 1
   - 178  # Cutscene showing off Bokoblin Base with Plats
+  - 187  # Watered Big Frog outside Fire Sanctuary
   - 198  # Can jump off Loftwing
   - 199  # Skip Eagus Cutscene after Sparring Hall chest
   - 201  # Talked to Stritch at Bug Island (Beedle always lost HCB)
@@ -165,6 +166,7 @@ Sceneflags:
     - 63 # Watched panning Cutscene showing pouch chest
     - 68 # Have talked to Plats near Volcano East
     - 70 # Watched initial panning Cutscene
+    - 100 # Watered Big Frog
     - 118 # Reveal Gossip Stone in Waterfall Area
     - 119 # Reveal Gossip Stone Near 2nd Frog
 


### PR DESCRIPTION
## What does this PR do?
Sets the sceneflag and storyflag for the Big Frog above the FS entrance so that the frog appears watered. I think this also removes some ember particles that were also in front of the FS entrance?

## How do you test this changes?
I genned a seed and the FS frog appeared watered :p