### PR TITLE
Fix buying Bug Net after turning in Beedle's Insect Cage

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -885,6 +885,9 @@
     index: 16
     flow:
       next: Check for Pouch
+  - name: Beedle Half Off Bug Net Text
+    type: textpatch
+    index: 26
   # shopsanity option stuff
   # - name: Second 100 Rupee Item
   #   onlyif: beedle_shop_shuffle != vanilla

--- a/data/text_data/english.yaml
+++ b/data/text_data/english.yaml
@@ -112,6 +112,9 @@
 - name: Item 213 Text
   standard: "You got the <s<Sky Keep>> Map!"
 
+- name: Beedle Half Off Bug Net Text
+  standard: "That's a <y<Bug Net>>. You know, for\ncatching bugs! Insects too.\n\n\nOK, so there aren't so many bugs here,\nbut you'll be able to catch tons with\nthis when there are some!\n\nAnd at half-price of only <r<25 Rupees>>,\nI'm sure you'll make a \"net profit\"!\nWant to buy it?\n[1]OK![2-]No, thanks."
+
 - name: Can't buy Pouch text
   standard: "You need an <y<Adventure Pouch>> to buy\nthis!"
 


### PR DESCRIPTION
## What does this PR do?
Adds in text for a choice to buy the bug net when the item is half-off.

## How do you test this changes?
I bought the bug net half off and it worked as expected.

