### PR TITLE
Fix AC Statue Reset

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -1878,10 +1878,11 @@
   # talk to the tablet and then lower the statue and reload
   - name: Statue Lower Question
     type: textpatch
-    index: 9
+    index: 4
+    textboxtype: 0
   - name: Replace Stone Tablet Fi Event
     type: flowpatch
-    index: 7
+    index: 5
     flow:
       next: Statue Lower Switch
   - name: Statue Lower Switch

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -4982,14 +4982,6 @@ D101: # Ancient Cistern
     layer: 0
     room: 4
     objtype: STAG
-  - name: Remove stone tablet text
-    type: objpatch
-    id: 0xFC11
-    layer: 0
-    room: 10
-    objtype: OBJ
-    object:
-      params1: 0xFF3C0000
   - name: Reload Exit
     type: objadd
     room: 10


### PR DESCRIPTION
## What does this PR do?
Not sure why the Fi text doesn't come up when checking the statue tablet, but it just doesn't. This changes the flowpatch to use the tablets flow index instead of the Fi text flow index

## How do you test this changes?
I talked to the tablet and the statue reset properly happened.
