### PR TITLE
Remove glitchy trigger for entering Fire Sanctuary cutscene

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -2696,6 +2696,12 @@ F201_3: # Outside Fire Sanctuary
     layer: 2
     room: 0
     objtype: OBJ
+  - name: Remove trigger for entering fire sanctuary cutscene
+    type: objdelete
+    id: 0xFC3E
+    layer: 0
+    room: 0
+    objtype: STAG
 
 F201_4: # Volcano Waterfall
   - name: Layer override


### PR DESCRIPTION
## What does this PR do?
Removes the trigger that normally plays the dramatic cutscene of Link entering the Fire Sanctuary. This trigger was being activated because we now set the frog above fire sanctuary to visibly be watered. However, the cutscene seemed to just be stuck infinitely (though you could skip it) so probably best to just remove it. 

## How do you test this changes?
I went into the entrance of Fire Sanctuary and entering the dungeon worked properly.

