### PR TITLE
Prevent Gorko (cube) from despawning after beating Skyview Temple

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -1774,6 +1774,14 @@ F101: # Deep Woods
     destlayer: 0
     room: 0
     objtype: SOBJ
+  - name: Don't despawn Gorko after beating Skyview Temple
+    type: objpatch
+    id: 0xFCF5
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      untrigstoryfid: -1
 
 F102: # Lake Floria
   - name: Layer override


### PR DESCRIPTION
## What does this PR do?
Removes the untrig storyflag from Gorko in Deep Woods. This prevents him from despawning after beating Skyview Temple

## How do you test this changes?
I beat Skyview Temple and Gorko was still in Deep Woods