### PR TITLE
Fix amiibo warp

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -758,7 +758,7 @@
       - 6 # Information
       - 5 # Play Time / Analysis
       - Display Fi Objective Text
-      - Display Fi Warp choice
+      - 5
       - -1
   - name: Patch Fi Call Information Option
     type: textpatch


### PR DESCRIPTION
## What does this PR do?
Fixes the issue that prevented Fi from allowing you to use the amiibo warp functionality

## How do you test this changes?
I tried to amiibo warp out of a save in Skyview Temple and I was able to successfully warp out (whereas I wasn't before the patch)

## Notes
Seems like it *was* related to Fi not being out of the sword first. Either that or something else that just happens to get set at the same time as that. The Fi menu is weird ^^'
