### PR TITLE
Add missing silent realm type to Skyloft Trial stamina fruit

### DIFF
--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -6894,6 +6894,7 @@
 - name: The Goddess's Silent Realm - Stamina Fruit on Knight Academy Ledge
   original_item: Stamina Fruit
   types:
+    - Silent Realms
     - Stamina Fruits
     - Custom Flag
   Paths:


### PR DESCRIPTION
## What does this PR do?
Gives `The Goddess's Silent Realm - Stamina Fruit on Knight Academy Ledge` check the `Silent Realms` type.

## How do you test this changes?
I opened the gui, filtered locations by `Silent Realms`, and the check now appeared in the list