### PR TITLE
Prevent harp from disabling the end of LMF loadzone

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -3462,6 +3462,7 @@ F300_5: # Lanayru Mining Facility to Temple of Time
       sizex: 1700
       sizez: 500
       trigstoryfid: 935
+      untrigstoryfid: 2047 # -1
   - name: End of LMF loadzone 2nd
     type: objdelete
     id: 0xFC04


### PR DESCRIPTION
## What does this PR do?
Prevents having the Goddess's Harp from disabling the loadzone at the end of LMF (hall of ancient robots).

## How do you test this changes?
I verified that having harp before this patch disabled the loadzone. I tested exiting the end of LMF with harp (and the patch) and the loadzone worked properly :p