### PR TITLE
Make rupees in 2nd LMF crawlspace advanced

### DIFF
--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -6055,7 +6055,7 @@
   original_item: Green Rupee
   types:
     - Freestanding Rupees
-    - Intermediate Rupees
+    - Advanced Rupees
     - Custom Flag
   Paths:
     - stage/D300_1/r9/l0/Item/0xFC07
@@ -6064,7 +6064,7 @@
   original_item: Green Rupee
   types:
     - Freestanding Rupees
-    - Intermediate Rupees
+    - Advanced Rupees
     - Custom Flag
   Paths:
     - stage/D300_1/r9/l0/Item/0xFC01


### PR DESCRIPTION
## What does this PR do?
Changes the type of the 2 rupees in the 2nd crawlspace of LMF from "Intermediate" to "Advanced". This is because you have to return to the main LMF room to collect the items which either means returning from where you came from or waiting until you've traversed the spike maze and exited out the other side