### PR TITLE
Rename use amiibo Fi option

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -763,6 +763,9 @@
   - name: Patch Fi Call Information Option
     type: textpatch
     index: 16
+  - name: Patch Fi Call Use amiibo Option
+    type: textpatch
+    index: 17
 
   # Fi Information
   - name: Fi Information Text Patch

--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -5733,6 +5733,9 @@
 - name: Patch Fi Call Information Option
   standard: "Information"
 
+- name: Patch Fi Call Use amiibo Option
+  standard: "Warp"
+
 - name: Forced Required Dungeons Text
   standard: "Welcome to your new adventure, Master. I have\n<r<important information>> about your journey."
 

--- a/data/text_data/es_US.yaml
+++ b/data/text_data/es_US.yaml
@@ -195,6 +195,9 @@
 - name: Patch Fi Call Information Option
   standard: "Información"
 
+- name: Patch Fi Call Use amiibo Option
+  standard: "Warp"
+
 # - name: Forced Required Dungeons Text
 #   standard: "Welcome to your new adventure, Master. I have\n<r<important information>> about your journey."
 


### PR DESCRIPTION
## What does this PR do?
In the main Fi menu, the "Use amiibo" option in the bottom left has been renamed simply to "Warp" instead.

## How do you test this changes?
I opened the Fi menu and the text was changed. Selecting the option allowed me to pick between "Warp to Start", "Use amiibo", and "Never mind."