### PR TITLE
Fix logic for opening gate of time

### DIFF
--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -55,7 +55,7 @@
   hint_region: Sealed Grounds
   events:
     Raise Gate of Time: Goddesss_Harp and Ballad_of_the_Goddess
-    Open Gate of Time: "Gate_of_Time_Sword_Requirement"
+    Open Gate of Time: "'Raise_Gate_of_Time' and Gate_of_Time_Sword_Requirement"
   exits:
     Sealed Grounds Spiral: Nothing
     Behind the Temple: Nothing


### PR DESCRIPTION
## What does this PR do?
Ensures opening the Gate of Time logically requires first raising the gate of time. This was accidentally removed when the GoT Sword Requirement was added.

## How do you test this changes?
I generated some logs, and the harp and ballad appeared in the playthrough.

## Notes

