### PR TITLE
Reduce F400 to layer 0

### DIFF
--- a/data/patches/extracts.yaml
+++ b/data/patches/extracts.yaml
@@ -1,292 +1,293 @@
 - stage: B100
   layers:
-  - layerid: 1
-    oarcs:
-    - GetHeartUtuwa
-    - PutHeartUtuwa
+    - layerid: 1
+      oarcs:
+        - GetHeartUtuwa
+        - PutHeartUtuwa
 
 - stage: B100_1
   layers:
-  - layerid: 0
-    oarcs:
-    - GetSekibanMapB
+    - layerid: 0
+      oarcs:
+        - GetSekibanMapB
+        - LittleBird
 
 - stage: B210
   layers:
-  - layerid: 0
-    oarcs:
-    - GetSekibanMapC
+    - layerid: 0
+      oarcs:
+        - GetSekibanMapC
 
 - stage: D003_0
   layers:
-  - layerid: 0
-    oarcs:
-    - PutTriForceSingle
-    - GetTriForceSingle
+    - layerid: 0
+      oarcs:
+        - PutTriForceSingle
+        - GetTriForceSingle
 
 - stage: D100
   layers:
-  - layerid: 0
-    oarcs:
-    - GetKeyBossA
-  - layerid: 1
-    oarcs:
-    - GetBeetleA
-    - SwitchEye
+    - layerid: 0
+      oarcs:
+        - GetKeyBossA
+    - layerid: 1
+      oarcs:
+        - GetBeetleA
+        - SwitchEye
 
 - stage: D101
   layers:
-  - layerid: 0
-    oarcs:
-    - GetKeyBoss2A
+    - layerid: 0
+      oarcs:
+        - GetKeyBoss2A
 
 - stage: D200
   layers:
-  - layerid: 0
-    oarcs:
-    - GetKeyBossB
+    - layerid: 0
+      oarcs:
+        - GetKeyBossB
 
 - stage: D201
   layers:
-  - layerid: 0
-    oarcs:
-    - GetKeyBoss2B
+    - layerid: 0
+      oarcs:
+        - GetKeyBoss2B
 
 - stage: D300
   layers:
-  - layerid: 0
-    oarcs:
-    - GetKeyBossC
+    - layerid: 0
+      oarcs:
+        - GetKeyBossC
 
 - stage: D301
   layers:
-  - layerid: 0
-    oarcs:
-    - GetBowA
-  - layerid: 9
-    oarcs:
-    - GoddessSymbolSc
-    - SwordCandle
-  - layerid: 11
-    oarcs:
-    - GetKeyBoss2C
+    - layerid: 0
+      oarcs:
+        - GetBowA
+    - layerid: 9
+      oarcs:
+        - GoddessSymbolSc
+        - SwordCandle
+    - layerid: 11
+      oarcs:
+        - GetKeyBoss2C
 
 - stage: F000
   layers:
-  - layerid: 0
-    oarcs:
-    - GetGaragara
-    - PutGaragara
-    - GetSeedLife
-    - GetSozaiP
-    - GossipStone
-  - layerid: 1
-    oarcs:
-    # - PLRemly
-    - ShinkanB
-  - layerid: 3
-    oarcs:
-    - RivalCmnAnm
-    - RivalNpcAnm
-  - layerid: 4
-    oarcs:
-    - GetShieldWood
-    - GetShieldHylia
-    - GetSozaiN
-    - GetSozaiO
-    - ShinkanA
-    - Shinkan_motion
-    # - GetSozaiP
+    - layerid: 0
+      oarcs:
+        - GetGaragara
+        - PutGaragara
+        - GetSeedLife
+        - GetSozaiP
+        - GossipStone
+    - layerid: 1
+      oarcs:
+        # - PLRemly
+        - ShinkanB
+    - layerid: 3
+      oarcs:
+        - RivalCmnAnm
+        - RivalNpcAnm
+    - layerid: 4
+      oarcs:
+        - GetShieldWood
+        - GetShieldHylia
+        - GetSozaiN
+        - GetSozaiO
+        - ShinkanA
+        - Shinkan_motion
+      # - GetSozaiP
 
 - stage: F001r
   layers:
-  - layerid: 3
-    oarcs:
-    - GetKobunALetter
-    - GetPouchA
+    - layerid: 3
+      oarcs:
+        - GetKobunALetter
+        - GetPouchA
 
 - stage: F002r
   layers:
-  - layerid: 0
-    oarcs:
-    - GetSparePurse
-  - layerid: 1
-    oarcs:
-    - GetPouchB
-    - GetMedal
-    - GetNetA
+    - layerid: 0
+      oarcs:
+        - GetSparePurse
+    - layerid: 1
+      oarcs:
+        - GetPouchB
+        - GetMedal
+        - GetNetA
 
 - stage: F004r
   layers:
-  - layerid: 0
-    oarcs:
-    - GetPachinkoB
-    - GetBowB
-    - GetBowC
-    - GetBeetleC
-    - GetBeetleD
-    - GetNetB
-    - GetSpareSeedA
-    - GetBottleMuteki
-    - GetBottleKusuri
-    - GetBottleGuts
-    - GetBottleAir
-    - GetBottleRepair
-    - GetSeedSet
-    - GetSpareQuiverA
-    - GetSpareBombBagA
-    - DesertRobot
+    - layerid: 0
+      oarcs:
+        - GetPachinkoB
+        - GetBowB
+        - GetBowC
+        - GetBeetleC
+        - GetBeetleD
+        - GetNetB
+        - GetSpareSeedA
+        - GetBottleMuteki
+        - GetBottleKusuri
+        - GetBottleGuts
+        - GetBottleAir
+        - GetBottleRepair
+        - GetSeedSet
+        - GetSpareQuiverA
+        - GetSpareBombBagA
+        - DesertRobot
 
 - stage: F008r
   layers:
-  - layerid: 1
-    oarcs:
-    - GetSekibanMapA
+    - layerid: 1
+      oarcs:
+        - GetSekibanMapA
 
 - stage: F009r
   layers:
-  - layerid: 0
-    oarcs:
-    - GetSwordA
+    - layerid: 0
+      oarcs:
+        - GetSwordA
 
 - stage: F012r
   layers:
-  - layerid: 0
-    oarcs:
-    - GetPurseB
-    - GetPurseC
-    - GetPurseD
-    - GetPurseE
+    - layerid: 0
+      oarcs:
+        - GetPurseB
+        - GetPurseC
+        - GetPurseD
+        - GetPurseE
 
 - stage: F020
   layers:
-  - layerid: 1
-    oarcs:
-    - GetBirdStatue
+    - layerid: 1
+      oarcs:
+        - GetBirdStatue
 
 - stage: F023
   layers:
-  - layerid: 0
-    oarcs:
-    - GetTerryCage
-  - layerid: 2
-    oarcs:
-    - KobunB
+    - layerid: 0
+      oarcs:
+        - GetTerryCage
+    - layerid: 2
+      oarcs:
+        - KobunB
 
 - stage: F100
   layers:
-  - layerid: 3
-    oarcs:
-    - PLHarpPlay
-    - SirenEntrance
-    - PLSwordStick
-  - layerid: 4
-    oarcs:
-    - ForestManWiz
-    - GetSozaiL
-    - SwrdPrj
+    - layerid: 3
+      oarcs:
+        - PLHarpPlay
+        - SirenEntrance
+        - PLSwordStick
+    - layerid: 4
+      oarcs:
+        - ForestManWiz
+        - GetSozaiL
+        - SwrdPrj
 
 - stage: F102_2
   layers:
-  - layerid: 4
-    oarcs:
-      - Waterdragon
+    - layerid: 4
+      oarcs:
+        - Waterdragon
 
 # F103
 - stage: F103
   layers:
-  - layerid: 2
-    oarcs:
-      - Onp
+    - layerid: 2
+      oarcs:
+        - Onp
 
 - stage: F200
   layers:
-  - layerid: 1
-    oarcs:
-    - GetKeyKakera
-  - layerid: 4
-    oarcs:
-      - FWRockB
-      - Ph
-      - PRing
-      - MoldWorm
-      - MoleBlock
-      - MoleGroundLn
-      - MoleGroundMl
-      - MoleGroundMn
-      - MoleGroundS
-      - MoleShutter
-      - PLMoleGlove
-      - MoundShovelB
+    - layerid: 1
+      oarcs:
+        - GetKeyKakera
+    - layerid: 4
+      oarcs:
+        - FWRockB
+        - Ph
+        - PRing
+        - MoldWorm
+        - MoleBlock
+        - MoleGroundLn
+        - MoleGroundMl
+        - MoleGroundMn
+        - MoleGroundS
+        - MoleShutter
+        - PLMoleGlove
+        - MoundShovelB
 
 - stage: F202
   layers:
-  - layerid: 1
-    oarcs:
-    - GetPachinkoA
-    - GetHookShot
-    - GetMoleGloveB
-    - GetVacuum
-    - GetWhip
-    - GetBombBag
+    - layerid: 1
+      oarcs:
+        - GetPachinkoA
+        - GetHookShot
+        - GetMoleGloveB
+        - GetVacuum
+        - GetWhip
+        - GetBombBag
 
 - stage: F210
   layers:
-  - layerid: 0
-    oarcs:
-    - GetMoleGloveA
+    - layerid: 0
+      oarcs:
+        - GetMoleGloveA
 
 - stage: F300
   layers:
-  - layerid: 0
-    oarcs:
-    - GetBeetleB
-    - GetSozaiH
-    - GetSozaiC
-    - GetSozaiF
+    - layerid: 0
+      oarcs:
+        - GetBeetleB
+        - GetSozaiH
+        - GetSozaiC
+        - GetSozaiF
 
 - stage: F301_5
   layers:
-  - layerid: 0
-    oarcs:
-    - GetMapSea
+    - layerid: 0
+      oarcs:
+        - GetMapSea
 
 - stage: F303
   layers:
-  - layerid: 1
-    oarcs:
-      - Goron_motion
-      - GoronD
+    - layerid: 1
+      oarcs:
+        - Goron_motion
+        - GoronD
 
 - stage: F402
   layers:
-  - layerid: 0
-    oarcs:
-    - GetFruitB
-  - layerid: 2
-    oarcs:
-    - GetHarp
+    - layerid: 0
+      oarcs:
+        - GetFruitB
+    - layerid: 2
+      oarcs:
+        - GetHarp
 
 - stage: S000
   layers:
-  - layerid: 2
-    oarcs:
-    - GetSirenKey
+    - layerid: 2
+      oarcs:
+        - GetSirenKey
 
 - stage: S100
   layers:
-  - layerid: 2
-    oarcs:
-    - GetSizuku
-    - GetUroko
+    - layerid: 2
+      oarcs:
+        - GetSizuku
+        - GetUroko
 
 - stage: S200
   layers:
-  - layerid: 2
-    oarcs:
-    - GetEarring
+    - layerid: 2
+      oarcs:
+        - GetEarring
 
 # For model texture stuff?
 - objectpack:
-  - Alink
-  - Bird_Link
+    - Alink
+    - Bird_Link

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -4041,15 +4041,9 @@ F400: # Behind the Temple
   - name: Layer override
     type: layeroverride
     override:
-      - story_flag: 13
+      - story_flag: -1
         night: 0
-        layer: 4
-      - story_flag: 9
-        night: 0
-        layer: 3
-      - story_flag: 36
-        night: 0
-        layer: 2
+        layer: 0
   - name: Add ammo pot to Behind the Temple Bird Statue
     onlyif: ammo_availability == plentiful
     type: objadd
@@ -4080,6 +4074,16 @@ F400: # Behind the Temple
     object:
       trigstoryfid: 2047
       untrigstoryfid: 2047
+  - name: Move Gorko stuff to layer 0
+    type: objmove
+    ids:
+      - 0xFC94 # Gorko
+      - 0xFC95 # Gorko trigger
+      - 0xFC99 # BtT Gates
+    layer: 3
+    destlayer: 0
+    room: 0
+    objtype: OBJ
   - name: Remove extra Gorkos and Fi text
     type: objdelete
     ids:
@@ -4095,6 +4099,18 @@ F400: # Behind the Temple
     layer: 0
     room: 0
     objtype: STAG
+  - name: Move birds to layer 0
+    type: objmove
+    id: 0xFC98
+    layer: 3
+    destlayer: 0
+    room: 0
+    objtype: STAG
+  - name: Add Little Bird Arc
+    type: oarcadd
+    oarc:
+      - LittleBird
+    destlayer: 0
 
 F401: # Sealed Grounds Whirlpool
   - name: Layer override


### PR DESCRIPTION
## What does this PR do?
Flattens the Behind the Temple stage down to just layer 0. This also has the nice side effect that the out-of-place enemy drums are gone too

## How do you test this changes?
I tested that I loaded into layer 0 from each entrance accessible in rando. I tested that Gorko's Goddess Wall still works. I tested that the BtT gates were still there and that the little birds were also there (although some of their sounds might not work on layer 0? it's hard to tell)