### PR TITLE
Flatten F102_2 to only use layer 0

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -1885,6 +1885,12 @@ F102_1: # Outside Ancient Cistern
     objtype: SNDT
 
 F102_2: # Faron's Lair
+  - name: Layer override
+    type: layeroverride
+    override: # always layer 0
+      - story_flag: -1
+        night: 0
+        layer: 0
   - name: Remove Faron's Lair entry cs
     type: objpatch
     index: 0


### PR DESCRIPTION
## What does this PR do?
Flatten Faron's Lair (F102_2) so that only layer 0 is used. Also fixes the weird bug where Faron is just chilling there without her basin

## How do you test this changes?
I loaded into the stage and everything was there except the dragon and her basin :p