### PR TITLE
Safer output cleanup

### DIFF
--- a/patches/allpatchhandler.py
+++ b/patches/allpatchhandler.py
@@ -1,4 +1,4 @@
-from filepathconstants import OBJECTPACK_PATH_TAIL
+from filepathconstants import OBJECTPACK_PATH_TAIL, SSHD_EXTRACT_PATH
 from gui.dialogs.dialog_header import print_progress_text, update_progress_value
 from logic.world import World
 from patches.asmpatchhandler import ASMPatchHandler
@@ -39,10 +39,21 @@ class AllPatchHandler:
         print_progress_text("Patching started")
 
         output_dir = self.world.config.output_dir
+        if output_dir == SSHD_EXTRACT_PATH:
+            raise Exception(
+                f"Output path cannot be the same as extract path (the randomizer cannot overwrite its own extract)."
+            )
 
-        if output_dir.exists() and output_dir.is_dir():
+        exefs_output = output_dir / "exefs"
+        romfs_output = output_dir / "romfs"
+
+        if exefs_output.exists() and exefs_output.is_dir():
             print_progress_text("Removing previous output")
-            rmtree(output_dir.as_posix())
+            rmtree(exefs_output.as_posix())
+
+        if romfs_output.exists() and romfs_output.is_dir():
+            print_progress_text("Removing previous output")
+            rmtree(romfs_output.as_posix())
 
         update_progress_value(16)
         self.stage_patch_handler.create_oarc_cache()

--- a/patches/stagepatchhandler.py
+++ b/patches/stagepatchhandler.py
@@ -385,9 +385,8 @@ def patch_tgreact(
     else:
         tgreact["params2"] = mask_shift_set(tgreact["params2"], 0x3FF, 8, 0x3FF)
 
-def patch_academy_bell(
-    bzs: dict, itemid: int, trapid: int
-):
+
+def patch_academy_bell(bzs: dict, itemid: int, trapid: int):
 
     academy_bell: dict | None = next(
         filter(lambda x: x["name"] == "Bell", bzs["OBJ "]), None


### PR DESCRIPTION
## What does this PR do?
Ensures that the rando only deletes the exefs and romfs folders in the output directory. Also halts randomization if the user tries to output to their extract folder, to prevent accidentally overwriting the extract.

## How do you test this changes?
I added a dummy folder to my output directory, and it remained after randomization. I tried to set my output to be my extract, and triggered the added Exception.