### PR TITLE
Prevent pots from disappearing due to viewclips

### DIFF
--- a/patches/stagepatchhandler.py
+++ b/patches/stagepatchhandler.py
@@ -550,6 +550,13 @@ def object_add(bzs: dict, object_add: dict, nextid: int) -> int:
         new_object["id"] = nextid + return_nextid_increment
         return_nextid_increment += 1
 
+    # Prevent ammo pots getting ids that collide with viewclip indexes
+    if new_object.get("name") == "Tubo":
+        id = new_object.get("id", -1)
+
+        if id != -1 and id < 0xF000:
+            new_object["id"] = id | 0xF000
+
     # creates list for object types if don't already exist in bzs
     if layer is None:
         if object_type not in bzs:  # check


### PR DESCRIPTION
## What does this PR do?
Makes sure that all pots added by the randomizer (only ammo pots are added at the moment) have an object id that doesn't collide with any viewclip ids.

Viewclip actors do a few things - one of which is to "freeze" any actors within their area. Viewclips have an index. Any actor with an object id staring with the same digit as the viewclip index *and* within the viewclip area (and if the player is in the area too) will get "frozen". This means that the game stops drawing the actor, stops updating it, and stops calculating its collision.

## How do you test this changes?
I found a pot that wasn't working properly (the one by the LMF bird statue near the wind gate in hub room), tested before my changes and the pot disappeared when I got close. Afterwards, it would remain visible and destroyable regardless of my position