### PR TITLE
Change trapish option to 10% of the junk pool

### DIFF
--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -502,7 +502,7 @@
     - "Traptacular"
   options:
     - "no_traps": "All items in the game will be genuine."
-    - "trapish": "Up to 10 non-major items will be replaced with 'traps' that don't give the item they appear to be."
+    - "trapish": "Approximately 10% of non-major items will be replaced with 'traps' that don't give the item they appear to be."
     - "trapsome": "Approximately 25% of non-major items will be replaced with 'traps' that don't give the item they appear to be."
     - "traps_o_plenty": "Approximately 50% of non-major items will be replaced with 'traps' that don't give the item they appear to be."
     - "traptacular": "All of the non-major items will be replaced with 'traps' that don't give the item they appear to be."

--- a/logic/world.py
+++ b/logic/world.py
@@ -525,7 +525,7 @@ class World:
 
         match self.setting("trap_mode"):
             case "trapish":
-                num_traps = 10
+                num_traps = len(non_major_item_pool) // 10
             case "trapsome":
                 num_traps = len(non_major_item_pool) // 4
             case "traps_o_plenty":


### PR DESCRIPTION
## What does this PR do?
Changes the lowest setting of `trap_mode` to replace 10% of the non-major items rather than just a fixed count of 10.

## How do you test this changes?
I generated a seed and checked the spoiler log to make sure that more than 10 traps were placed