### PR TITLE
Allow getting Ledd's Gift without opening the chest

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -2257,6 +2257,46 @@
     index: 21
     flow:
       next: -1
+  - name: Patch Ledd text before Gift
+    type: flowpatch
+    index: 7
+    flow:
+      next: Check if already given Gift
+  - name: Check if already given Gift
+    type: checksceneflag
+    flow:
+      checksceneflag: 45 # Received Ledd's Gift
+    cases:
+      - 90 # Continue as normal
+      - Check if defeated Lizalfos
+  - name: Check if defeated Lizalfos
+    type: checksceneflag
+    flow:
+      checksceneflag: 2 # Double Lizalfos Defeated
+    cases:
+      - Show Attention Mark
+      - 90 # Continue as normal
+  - name: Show Attention Mark
+    type: attentionmark
+    flow:
+      next: 89 # Give item
+  - name: Goto Give sceneflag after Gift
+    type: flowpatch
+    index: 16
+    flow:
+      next: Give Gift sceneflag
+  - name: Give Gift sceneflag
+    type: setsceneflag
+    flow:
+      sceneindex: 14 # Earth Temple
+      setsceneflag: 45
+      next: 17 # post-Gift text
+  - name: Always give same post-gift text
+    type: flowpatch
+    index: 91
+    flow:
+      next: 12
+
 
 302-Anahori:
   - name: To Mitts Check

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -5270,9 +5270,10 @@ D200: # Earth Temple
   - name: Remove text triggers
     type: objdelete
     ids:
-      - 0xFC51 # Ledd text before Bomb Bag
-      - 0xFC52 # Bomb Bag from Ledd
-      - 0xFC5E # Fi text after bridge
+      - 0xFC51 # Ledd text before Bomb Bag (NpcTke)
+      - 0xFC52 # Bomb Bag from Ledd (NpcTke)
+      - 0xFC53 # 5 Bombs from Ledd (NpcTke)
+      - 0xFC5E # Fi text after bridge (NpcTke)
     layer: 0
     room: 1
     objtype: OBJ


### PR DESCRIPTION
## What does this PR do?
Allows getting the `Earth Temple - Ledd's Gift` check without opening the `Earth Temple - Chest after Double Lizalfos Fight`. You can now get Ledd's Gift after defeating the 2 Lizalfos. This also removes the invisible trigger for getting the check. Instead, Ledd will now have an attention mark above his head to prompt you to talk to him. This allows you to ignore the check if it's been hinted.

## How do you test this changes?
I generated a seed, talked to Ledd before defeating the lizalfos, after defeating the lizalfos, after correctly obtaining the gift without opening the chest, and again after opening the chest. All worked as expected :p