### PR TITLE
Limit starting location option

### DIFF
--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -362,6 +362,16 @@
     - any_surface_region: "You will start the game at any surface region entrance or in Link's Bedroom."
     - anywhere: "You will start the game at any valid entrance."
 
+- name: limit_starting_spawn
+  default_option: "off"
+  pretty_name: Limit Starting Spawn
+  pretty_options:
+    - "Off"
+    - "On"
+  options:
+    - "off": "If you spawn in a surface region, you may spawn in any surface province."
+    - "on": "If you spawn in a surface region, you may only spawn in a province whose tablet you start with."
+
 - name: randomize_dungeon_entrances
   default_option: "off"
   pretty_name: Randomize Dungeon Entrances

--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1275</width>
+    <width>1387</width>
     <height>845</height>
    </rect>
   </property>
@@ -36,7 +36,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>5</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="getting_started_tab">
        <property name="sizePolicy">
@@ -498,9 +498,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
                     <property name="editable">
                      <bool>false</bool>
                     </property>
-                    <property name="placeholderText">
-                     <string>Select Font Family</string>
-                    </property>
                     <property name="fontFilters">
                      <set>QFontComboBox::ScalableFonts</set>
                     </property>
@@ -509,6 +506,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                       <family>Arial</family>
                       <pointsize>10</pointsize>
                      </font>
+                    </property>
+                    <property name="placeholderText" stdset="0">
+                     <string>Select Font Family</string>
                     </property>
                    </widget>
                   </item>
@@ -1355,6 +1355,13 @@ li.checked::marker { content: &quot;\2612&quot;; }
             <widget class="QComboBox" name="setting_random_starting_spawn"/>
            </item>
            <item>
+            <widget class="QCheckBox" name="setting_random_starting_spawn">
+             <property name="text">
+              <string>Limit Starting Spawn</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="RandoTriStateCheckBox" name="setting_random_starting_statues">
              <property name="text">
               <string>Random Starting Statues</string>
@@ -1793,7 +1800,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
             <layout class="QHBoxLayout" name="included_locations_filter_layout">
              <item>
               <widget class="QComboBox" name="included_locations_type_filter">
-               <property name="placeholderText">
+               <property name="placeholderText" stdset="0">
                 <string/>
                </property>
               </widget>

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -936,6 +936,11 @@ class Ui_main_window(object):
 
         self.verticalLayout_17.addWidget(self.setting_random_starting_spawn)
 
+        self.setting_limit_starting_spawn = RandoTriStateCheckBox(self.entrance_randomization_group_box)
+        self.setting_limit_starting_spawn.setObjectName(u"setting_limit_starting_spawn")
+
+        self.verticalLayout_17.addWidget(self.setting_limit_starting_spawn)
+
         self.setting_random_starting_statues = RandoTriStateCheckBox(self.entrance_randomization_group_box)
         self.setting_random_starting_statues.setObjectName(u"setting_random_starting_statues")
 
@@ -2401,6 +2406,7 @@ class Ui_main_window(object):
         self.setting_randomize_dungeon_entrances.setText(QCoreApplication.translate("main_window", u"Randomize Dungeon Entrances", None))
         self.setting_randomize_trial_gate_entrances.setText(QCoreApplication.translate("main_window", u"Randomize Trial Gate Entrances", None))
         self.random_starting_spawn_label.setText(QCoreApplication.translate("main_window", u"Randomize Starting Spawn", None))
+        self.setting_limit_starting_spawn.setText(QCoreApplication.translate("main_window", u"Limit Starting Spawn", None))
         self.setting_random_starting_statues.setText(QCoreApplication.translate("main_window", u"Random Starting Statues", None))
         self.setting_decouple_double_doors.setText(QCoreApplication.translate("main_window", u"Decouple Double Door Entrances", None))
         self.setting_decouple_entrances.setText(QCoreApplication.translate("main_window", u"Decouple Entrances", None))

--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -1,3 +1,4 @@
+from constants.itemnames import AMBER_TABLET, EMERALD_TABLET, RUBY_TABLET
 from filepathconstants import BIRD_STATUE_DATA_PATH, ENTRANCE_SHUFFLE_DATA_PATH
 from .entrance import *
 from .item import Item
@@ -318,21 +319,54 @@ def create_spawn_target_pool(world: World) -> list[Entrance]:
     # Determine all possible starting targets depending on settings
     target_pool: list[Entrance] = []
     starting_spawn_value = world.setting("random_starting_spawn").value()
+    banned_spawn_regions = set[str]({})
+    if world.setting("limit_starting_spawn").value() == "on":
+        if world.starting_item_pool[world.get_item(EMERALD_TABLET)] == 0:
+            banned_spawn_regions |= {
+                "Sealed Grounds",
+                "Faron Woods",
+                "Lake Floria",
+                "Inside the Great Tree",
+            }
+        if world.starting_item_pool[world.get_item(RUBY_TABLET)] == 0:
+            banned_spawn_regions |= {
+                "Eldin Volcano",
+                "Mogma Turf",
+                "Volcano Summit",
+                "Bokoblin Base",
+            }
+        if world.starting_item_pool[world.get_item(AMBER_TABLET)] == 0:
+            banned_spawn_regions |= {
+                "Lanayru Mine",
+                "Lanayru Desert",
+                "Temple of Time",
+                "Lanayru Caves",
+                "Ancient Harbour",
+                "Lanayru Sand Sea",
+                "Lanayru Gorge",
+            }
+
     match starting_spawn_value:
         case "vanilla":
             assert False  # Should never be hit
         case "bird_statues":
             for entrance_type in ["Bird Statue", "Spawn"]:
                 for entrance in world.get_shuffleable_entrances(entrance_type):
-                    target_pool.append(entrance.get_new_target())
+                    if (
+                        entrance.can_start_at
+                        and not entrance.parent_area.get_regions().intersection(
+                            banned_spawn_regions
+                        )
+                    ):
+                        target_pool.append(entrance.get_new_target())
         case "any_surface_region":
-            banned_spawn_regions = {
+            banned_spawn_regions |= {
                 "Knight Academy",
                 "Upper Skyloft",
                 "Central Skyloft",
                 "Skyloft Village",
                 "Bazaar",
-                "Batreaux",
+                "Batreaux's House",
                 "The Sky",
                 "Inside the Thunderhead",
             }
@@ -357,7 +391,12 @@ def create_spawn_target_pool(world: World) -> list[Entrance]:
                 "Spawn",
             ]:
                 for entrance in world.get_shuffleable_entrances(entrance_type):
-                    if entrance.can_start_at:
+                    if (
+                        entrance.can_start_at
+                        and not entrance.parent_area.get_regions().intersection(
+                            banned_spawn_regions
+                        )
+                    ):
                         target_pool.append(entrance.get_new_target())
         case _:
             raise EntranceShuffleError(


### PR DESCRIPTION
## What does this PR do?
Adds an option to limit random starting location to regions you start with a tablet for.

## How do you test this change?
I enabled the option and started with each pillar, and got an appropriate starting location. My location was not on the surface with zero tablets to start with.
