### PR TITLE
Properly check for sphere zero locations during entrance randomization

### DIFF
--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -320,7 +320,7 @@ def create_spawn_target_pool(world: World) -> list[Entrance]:
     target_pool: list[Entrance] = []
     starting_spawn_value = world.setting("random_starting_spawn").value()
     banned_spawn_regions = set[str]({})
-    if world.setting("limit_starting_spawn").value() == "on":
+    if world.setting("limit_starting_spawn") == "on":
         if world.starting_item_pool[world.get_item(EMERALD_TABLET)] == 0:
             banned_spawn_regions |= {
                 "Sealed Grounds",

--- a/logic/search.py
+++ b/logic/search.py
@@ -72,6 +72,7 @@ class Search:
                     if not loc_access.location.is_empty() or self.search_mode in [
                         SearchMode.ACCESSIBLE_LOCATIONS,
                         SearchMode.ALL_LOCATIONS_REACHABLE,
+                        SearchMode.SPHERE_ZERO,
                     ]:
                         item_locations.append(loc_access)
 


### PR DESCRIPTION
## What does this PR do?
Turns out the ER validation was including some non-progress checks where it shouldn't have been. Non-progress locations (except for barren dungeons) are now assigned before any entrance shuffling takes place. Barren dungeon locations are still assigned afterwards, but this is fine for now.

## How do you test this changes?
I generated a bunch of ER seeds and made sure that only progression locations were being considered during world validation.

