### PR TITLE
Temp Alink and Bird_Link modding support

### DIFF
--- a/constants/randoconstants.py
+++ b/constants/randoconstants.py
@@ -1,1 +1,1 @@
-VERSION = "0.0+dev_6"
+VERSION = "0.0+dev_7"

--- a/patches/allpatchhandler.py
+++ b/patches/allpatchhandler.py
@@ -1,4 +1,4 @@
-from filepathconstants import SSHD_EXTRACT_PATH
+from filepathconstants import OBJECTPACK_PATH_TAIL, SSHD_EXTRACT_PATH
 from gui.dialogs.dialog_header import print_progress_text, update_progress_value
 from logic.world import World
 from patches.asmpatchhandler import ASMPatchHandler
@@ -16,6 +16,8 @@ from patches.stagepatchhandler import StagePatchHandler
 from patches.eventpatchhandler import EventPatchHandler
 from patches.dynamictextpatches import add_dynamic_text_patches
 from shutil import rmtree
+
+from patches.temp_objectpack_texture_replace_hack import patch_object_pack
 
 
 class AllPatchHandler:
@@ -71,6 +73,8 @@ class AllPatchHandler:
         determine_entrance_patches(
             self.world.get_shuffled_entrances(), self.stage_patch_handler
         )
+
+        patch_object_pack(self.world.config.output_dir / OBJECTPACK_PATH_TAIL)
 
         print_progress_text("Patching Stages")
         patch_required_dungeon_text_trigger(self.world, self.stage_patch_handler)

--- a/patches/temp_objectpack_texture_replace_hack.py
+++ b/patches/temp_objectpack_texture_replace_hack.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from filepathconstants import (
+    OBJECTPACK_PATH,
+    OARC_CACHE_PATH,
+)
+from sslib.utils import write_bytes_create_dirs
+from sslib.u8file import U8File
+
+
+def patch_object_pack(object_pack_output_path: Path):
+    objectpack_arc = U8File.get_parsed_U8_from_path(OBJECTPACK_PATH, True)
+
+    for arc in ("Alink", "Bird_Link"):
+        arc_name = f"{arc}.arc"
+        oarc_path = OARC_CACHE_PATH / arc_name
+
+        if oarc_path.exists():
+            objectpack_arc.add_file_data(f"oarc/{arc_name}", oarc_path.read_bytes())
+        else:
+            raise Exception(f"ERROR: {arc_name} not found in oarc cache.")
+
+    write_bytes_create_dirs(
+        object_pack_output_path, objectpack_arc.build_and_compress_U8()
+    )


### PR DESCRIPTION
## What does this PR do?
Nothing fancy, just replaces `Alink.arc` and `Bird_Link.arc` in `ObjectPack.arc.LZ` with the ones in `oarccache`. This allows ppl to replace the textures/model in those files and they will get applied when generating seeds. Temp and hacky - should be replaced with a more sophisticated solution in the future

## How do you test this changes?
I tested with an Alink model with a replaced hat texture. The rando patched it and the game worked with the new texture