### PR TITLE
Fix full wallet upgrades always being on

### DIFF
--- a/patches/eventpatchhandler.py
+++ b/patches/eventpatchhandler.py
@@ -157,7 +157,7 @@ class EventPatchHandler:
                             if statement := patch.get("onlyif", False):
                                 if not onlyif_handler.evaluate_onlyif(statement):
                                     continue
-                                
+
                             if (
                                 patch["type"]
                                 in FLOW_ADD_VARIATIONS + SWITCH_ADD_VARIATIONS


### PR DESCRIPTION
## What does this PR do?
Event patches' `onlyif` statements were only being checked for textadds/patches, but not for flowadds/patches. This adds the necessary check in which fixes the issue of `full_wallet_upgrades` always getting patched in.

## How do you test this changes?
I generated seeds with `full_wallet_upgrades` on and off and the behavior was what would be expected.
