### PR TITLE
Remove the map opening after saving the SSH crew

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -2615,6 +2615,11 @@
       param2: 0 # current room
       next: -1
       param3: 10
+  - name: Remove opening the map after saving the crew
+    type: flowpatch
+    index: 43
+    flow:
+      next: 28
 
 402-DesertF2:
   - name: Override Skipper check for first time conversation


### PR DESCRIPTION
## What does this PR do?
Removes the map opening part of the cutscene when saving the SSH crew. This not only reduces necessary input, but also prevents players from accidentally softlocking if they enter the cutscene with the pouch UI open. 

## How do you test this changes?
I went through the cutscene and the map didn't open at all.
