### PR TITLE
Don't place vanilla items in disabled Goddess Chests

### DIFF
--- a/logic/world.py
+++ b/logic/world.py
@@ -362,7 +362,7 @@ class World:
                 )
                 or (
                     location in disabled_shuffle_locations
-                    and "Goddess Chests" in location.types
+                    and "Goddess Chests" not in location.types
                 )
             ):
                 location.set_current_item(item)


### PR DESCRIPTION
## What does this PR do?
When Goddess Chests are disabled, they won't get their vanilla items anymore (they'll just get junk items). This was causing a problem where the game was considering the Progressive Pouch at `Lumpy Pumpkin - Goddess Chest near Gossip Stone` as something the player could logically obtain to progress. Normally we want to still consider vanilla item locations for progression because of keys and single gratitude crystals, so this was the easiest way to prevent the outlier.

## How do you test this changes?
I generated some seeds, and goddess chests didn't get any major items.
