### PR TITLE
Check for stage when patching Required Dungeons Fi Trigger

### DIFF
--- a/patches/entrancepatchhandler.py
+++ b/patches/entrancepatchhandler.py
@@ -61,7 +61,11 @@ def patch_required_dungeon_text_trigger(
     else:
         entrance_info = starting_entrance.replaces.spawn_info[0]
 
-    stage_patch_handler.stage_patches[entrance_info["stage"]].append(
+    stage = entrance_info["stage"]
+    if stage not in stage_patch_handler.stage_patches:
+        stage_patch_handler.stage_patches[stage] = []
+
+    stage_patch_handler.stage_patches[stage].append(
         {
             "name": "Add NpcTke Required Dungeon Text Trigger",
             "type": "objadd",


### PR DESCRIPTION
## What does this PR do?
Adds a check to make sure the stage name exists in the stage patches before adding the stage patch for the required dungeons fi trigger.

## How do you test this changes?
I generated a seed that was previously throwing an error during the required dungeons fi text patch, and it generated and functioned fine. 
