### PR TITLE
Add air vent to Guld platform

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -3025,6 +3025,24 @@ F210: # Mogma Turf
       - story_flag: -1
         night: 0
         layer: 1
+  - name: Add air vent to Guld platform
+    type: objadd
+    layer: 0
+    room: 0
+    objtype: SOBJ
+    object:
+      params1: 0x7FFFF027
+      params2: 0xFFDFFFFF
+      posx: 2500
+      posy: -7390
+      posz: 2200
+      sizex: 1.5
+      sizey: 8.5
+      sizez: 1.5
+      anglex: 364
+      angley: 25000
+      anglez: 1023
+      name: Wind
   - name: Add ammo pot to Mogma Turf Bird Statue
     onlyif: ammo_availability == useful or ammo_availability == plentiful
     type: objadd


### PR DESCRIPTION
## What does this PR do?
Adds an air vent that takes you up to the Guld platform. Useful if you're entering Mogma Turf for the first time and want/need to land on all of the platforms. Doesn't change logic, just prevents you having to take the sky dive again

## How do you test this changes?
I tested that the vent works - even if you approach it from different angles

## Notes
This is something Nino suggested ages ago :p