### PR TITLE
Update logic for unlocking the Great Tree statue from FFW

### DIFF
--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -339,7 +339,7 @@
     Unlock In the Woods Statue: Water_Dragons_Scale
     Unlock Viewing Platform Statue: Water_Dragons_Scale
     Unlock Faron Woods Entry Statue: Water_Dragons_Scale
-    Unlock The Great Tree Statue: Nothing
+    Unlock The Great Tree Statue: Clawshots or Water_Dragons_Scale
     Retrieve Oolo: Scrapper and 'Start_Owlans_Quest'
     Can Watch Completed Tadtones Cutscene: Nothing
     Can Collect Water: Bottle


### PR DESCRIPTION
## What does this PR do?
Fixes an issue where logic considered accessing Flooded Faron Woods gives access to the Great Tree statue. Since the entry into FFW isn't from the top of the Great Tree anymore, this isn't accurate :p