### PR TITLE
Fix current_option_index not getting properly updated

### DIFF
--- a/logic/settings.py
+++ b/logic/settings.py
@@ -91,7 +91,9 @@ class Setting:
             random_options = self.info.options[
                 self.info.random_low : self.info.random_high + 1
             ]
-            self.update_current_value(self.info.options.index(random.choice(random_options)))
+            self.update_current_value(
+                self.info.options.index(random.choice(random_options))
+            )
             logging.getLogger("").debug(
                 f"Chose {self.value} as random option for {self.name}"
             )


### PR DESCRIPTION
## What does this PR do?
a setting's current_option_index is now properly updated when resolving from random. This was causing random sky/cloud colors to not get applied properly. 

## How do you test this changes?
I set cloud and sky colors to all be random and they were the randomly chosen options
