### PR TITLE
Fix inconsistent starting entrance

### DIFF
--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -417,7 +417,7 @@ def create_spawn_target_pool(world: World) -> list[Entrance]:
                 f"Unknown value for random starting spawn: '{starting_spawn_value}'"
             )
 
-    for entrance_type in shuffled_entrance_types:
+    for entrance_type in sorted(shuffled_entrance_types):
         for entrance in world.get_shuffleable_entrances(entrance_type):
             if can_start_at_entrance(entrance):
                 new_target_entrance = entrance.get_new_target()


### PR DESCRIPTION
## What does this PR do?
Sorts the set of entrance types for making the spawn target entrances. Previously the set order wasn't guaranteed

## How do you test this changes?
I generated multiple seeds and had the same "anywhere" starting location each time.

