### PR TITLE
Disable Beedle's Shop until it's implemented

### DIFF
--- a/data/items.yaml
+++ b/data/items.yaml
@@ -591,11 +591,11 @@
   getarcname: GetPurseB
   getmodelname: GetPurseB
   advancement: true
-  chain_locations:
-   - Beedle's Airshop - 600 Rupee Item
-   - Beedle's Airshop - 1200 Rupee Item
-   - Beedle's Airshop - 800 Rupee Item
-   - Beedle's Airshop - 1600 Rupee Item
+  # chain_locations:
+  #  - Beedle's Airshop - 600 Rupee Item
+  #  - Beedle's Airshop - 1200 Rupee Item
+  #  - Beedle's Airshop - 800 Rupee Item
+  #  - Beedle's Airshop - 1600 Rupee Item
 - id: 109
   name: Big Wallet
   types:
@@ -970,11 +970,11 @@
   getarcname: GetSparePurse
   getmodelname: GetSparePurse
   advancement: true
-  chain_locations:
-   - Beedle's Airshop - 600 Rupee Item
-   - Beedle's Airshop - 1200 Rupee Item
-   - Beedle's Airshop - 800 Rupee Item
-   - Beedle's Airshop - 1600 Rupee Item
+  # chain_locations:
+  #  - Beedle's Airshop - 600 Rupee Item
+  #  - Beedle's Airshop - 1200 Rupee Item
+  #  - Beedle's Airshop - 800 Rupee Item
+  #  - Beedle's Airshop - 1600 Rupee Item
 
 # Custom rando items
 - id: 200

--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -1002,97 +1002,97 @@
 
 
 # Beedle's Airshop:
-- name: Beedle's Airshop - 300 Rupee Item
-  original_item: Progressive Pouch
-  types:
-    - Beedle's Airshop
-    - Shop (Cheap)
-    - NPC
-  Paths:
-    - ShpSmpl/20
+# - name: Beedle's Airshop - 300 Rupee Item
+#   original_item: Progressive Pouch
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Cheap)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/20
 
-- name: Beedle's Airshop - 600 Rupee Item
-  original_item: Progressive Pouch
-  types:
-    - Beedle's Airshop
-    - Shop (Medium)
-    - NPC
-  Paths:
-    - ShpSmpl/21
+# - name: Beedle's Airshop - 600 Rupee Item
+#   original_item: Progressive Pouch
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Medium)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/21
 
-- name: Beedle's Airshop - 1200 Rupee Item
-  original_item: Progressive Pouch
-  types:
-    - Beedle's Airshop
-    - Shop (Expensive)
-    - NPC
-  hint: always
-  Paths:
-    - ShpSmpl/22
+# - name: Beedle's Airshop - 1200 Rupee Item
+#   original_item: Progressive Pouch
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Expensive)
+#     - NPC
+#   hint: always
+#   Paths:
+#     - ShpSmpl/22
 
-- name: Beedle's Airshop - 800 Rupee Item
-  original_item: Life Medal
-  types:
-    - Beedle's Airshop
-    - Shop (Medium)
-    - NPC
-  Paths:
-    - ShpSmpl/26
+# - name: Beedle's Airshop - 800 Rupee Item
+#   original_item: Life Medal
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Medium)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/26
 
-- name: Beedle's Airshop - 1600 Rupee Item
-  original_item: Heart Piece
-  types:
-    - Beedle's Airshop
-    - Shop (Expensive)
-    - NPC
-  hint: always
-  Paths:
-    - ShpSmpl/23
+# - name: Beedle's Airshop - 1600 Rupee Item
+#   original_item: Heart Piece
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Expensive)
+#     - NPC
+#   hint: always
+#   Paths:
+#     - ShpSmpl/23
 
-- name: Beedle's Airshop - First 100 Rupee Item
-  original_item: Extra Wallet
-  types:
-    - Beedle's Airshop
-    - Shop (Cheap)
-    - NPC
-  Paths:
-    - ShpSmpl/24
+# - name: Beedle's Airshop - First 100 Rupee Item
+#   original_item: Extra Wallet
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Cheap)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/24
 
-- name: Beedle's Airshop - Second 100 Rupee Item
-  original_item: Extra Wallet
-  types:
-    - Beedle's Airshop
-    - Shop (Cheap)
-    - NPC
-  Paths:
-    - ShpSmpl/17
+# - name: Beedle's Airshop - Second 100 Rupee Item
+#   original_item: Extra Wallet
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Cheap)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/17
 
-- name: Beedle's Airshop - Third 100 Rupee Item
-  original_item: Extra Wallet
-  types:
-    - Beedle's Airshop
-    - Shop (Cheap)
-    - NPC
-  Paths:
-    - ShpSmpl/18
+# - name: Beedle's Airshop - Third 100 Rupee Item
+#   original_item: Extra Wallet
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Cheap)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/18
 
-- name: Beedle's Airshop - 50 Rupee Item
-  original_item: Progressive Bug Net
-  types:
-    - Beedle's Airshop
-    - Shop (Cheap)
-    - NPC
-  Paths:
-    - ShpSmpl/25
+# - name: Beedle's Airshop - 50 Rupee Item
+#   original_item: Progressive Bug Net
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Cheap)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/25
 
-- name: Beedle's Airshop - 1000 Rupee Item
-  original_item: Bug Medal
-  types:
-    - Beedle's Airshop
-    - Shop (Medium)
-    - NPC
-  Paths:
-    - ShpSmpl/27
+# - name: Beedle's Airshop - 1000 Rupee Item
+#   original_item: Bug Medal
+#   types:
+#     - Beedle's Airshop
+#     - Shop (Medium)
+#     - NPC
+#   Paths:
+#     - ShpSmpl/27
 
 
 # The Sky:

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -996,6 +996,40 @@ F002r: # Beedle's Airshop
     layer: 1
     room: 0
     objtype: STAG
+  # Remove these when beedle's shop
+  # becomes randomized
+  - name: Make item 1 sold out
+    type: objpatch
+    id: 0xFC09
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xFFFFFFFF
+  - name: Make item 2 sold out
+    type: objpatch
+    id: 0xFC0A
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xFFFFFFFF
+  - name: Make item 3 sold out
+    type: objpatch
+    id: 0xFC0B
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xFFFFFFFF
+  - name: Make item 4 sold out
+    type: objpatch
+    id: 0xFC0C
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xFFFFFFFF
 
 F004r: # Bazaar
   - name: Remove goddess chest fi text

--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -472,16 +472,16 @@
   exits:
     Beedle's Island: Night
     Central Skyloft: Day
-  locations:
-    # We don't want the pouch extensions to be the logical access to the pouch
-    Beedle's Airshop - 300 Rupee Item: Can_Afford_300_Rupees and (Pouch or beedle_shop_shuffle != vanilla)
-    Beedle's Airshop - 600 Rupee Item: Can_Afford_600_Rupees and (Pouch or beedle_shop_shuffle != vanilla)
-    Beedle's Airshop - 1200 Rupee Item: Can_Afford_1200_Rupees and (Pouch or beedle_shop_shuffle != vanilla)
-    Beedle's Airshop - 800 Rupee Item: Can_Afford_800_Rupees
-    Beedle's Airshop - 1600 Rupee Item: Can_Afford_1600_Rupees
-    Beedle's Airshop - First 100 Rupee Item: Can_Afford_100_Rupees
-    Beedle's Airshop - Second 100 Rupee Item: Can_Afford_100_Rupees
-    # To reduce necessary rupee-farming at the start, the third item logically needs an efficient rupee-farming method
-    Beedle's Airshop - Third 100 Rupee Item: Can_Afford_100_Rupees and Can_Medium_Rupee_Farm
-    Beedle's Airshop - 50 Rupee Item: Can_Afford_50_Rupees
-    Beedle's Airshop - 1000 Rupee Item: Can_Afford_1000_Rupees
+  # locations:
+  #   # We don't want the pouch extensions to be the logical access to the pouch
+  #   Beedle's Airshop - 300 Rupee Item: Can_Afford_300_Rupees and (Pouch or beedle_shop_shuffle != vanilla)
+  #   Beedle's Airshop - 600 Rupee Item: Can_Afford_600_Rupees and (Pouch or beedle_shop_shuffle != vanilla)
+  #   Beedle's Airshop - 1200 Rupee Item: Can_Afford_1200_Rupees and (Pouch or beedle_shop_shuffle != vanilla)
+  #   Beedle's Airshop - 800 Rupee Item: Can_Afford_800_Rupees
+  #   Beedle's Airshop - 1600 Rupee Item: Can_Afford_1600_Rupees
+  #   Beedle's Airshop - First 100 Rupee Item: Can_Afford_100_Rupees
+  #   Beedle's Airshop - Second 100 Rupee Item: Can_Afford_100_Rupees
+  #   # To reduce necessary rupee-farming at the start, the third item logically needs an efficient rupee-farming method
+  #   Beedle's Airshop - Third 100 Rupee Item: Can_Afford_100_Rupees and Can_Medium_Rupee_Farm
+  #   Beedle's Airshop - 50 Rupee Item: Can_Afford_50_Rupees
+  #   Beedle's Airshop - 1000 Rupee Item: Can_Afford_1000_Rupees

--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>7</number>
+       <number>3</number>
       </property>
       <widget class="QWidget" name="getting_started_tab">
        <property name="sizePolicy">
@@ -1637,13 +1637,20 @@
           <layout class="QVBoxLayout" name="verticalLayout_10">
            <item>
             <widget class="QLabel" name="beedle_shop_shuffle_label">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="text">
               <string>Beedle's Airshop Shuffle</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="setting_beedle_shop_shuffle"/>
+            <widget class="QComboBox" name="setting_beedle_shop_shuffle">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QLabel" name="rupee_shuffle_label">

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'main.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.2
+## Created by: Qt User Interface Compiler version 6.7.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -808,8 +808,8 @@ class Ui_main_window(object):
 
         self.line = QFrame(self.open_dungeons_group_box)
         self.line.setObjectName(u"line")
-        self.line.setFrameShape(QFrame.HLine)
-        self.line.setFrameShadow(QFrame.Sunken)
+        self.line.setFrameShape(QFrame.Shape.HLine)
+        self.line.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_25.addWidget(self.line)
 
@@ -1012,8 +1012,8 @@ class Ui_main_window(object):
 
         self.mixed_entrance_pools_hline = QFrame(self.mixed_entrance_pools_group_box)
         self.mixed_entrance_pools_hline.setObjectName(u"mixed_entrance_pools_hline")
-        self.mixed_entrance_pools_hline.setFrameShape(QFrame.HLine)
-        self.mixed_entrance_pools_hline.setFrameShadow(QFrame.Sunken)
+        self.mixed_entrance_pools_hline.setFrameShape(QFrame.Shape.HLine)
+        self.mixed_entrance_pools_hline.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_28.addWidget(self.mixed_entrance_pools_hline)
 
@@ -1093,11 +1093,13 @@ class Ui_main_window(object):
         self.verticalLayout_10.setObjectName(u"verticalLayout_10")
         self.beedle_shop_shuffle_label = QLabel(self.shuffles_group_box)
         self.beedle_shop_shuffle_label.setObjectName(u"beedle_shop_shuffle_label")
+        self.beedle_shop_shuffle_label.setEnabled(False)
 
         self.verticalLayout_10.addWidget(self.beedle_shop_shuffle_label)
 
         self.setting_beedle_shop_shuffle = QComboBox(self.shuffles_group_box)
         self.setting_beedle_shop_shuffle.setObjectName(u"setting_beedle_shop_shuffle")
+        self.setting_beedle_shop_shuffle.setEnabled(False)
 
         self.verticalLayout_10.addWidget(self.setting_beedle_shop_shuffle)
 
@@ -2112,8 +2114,8 @@ class Ui_main_window(object):
 
         self.utils_hline = QFrame(self.file_setup_group_box)
         self.utils_hline.setObjectName(u"utils_hline")
-        self.utils_hline.setFrameShape(QFrame.HLine)
-        self.utils_hline.setFrameShadow(QFrame.Sunken)
+        self.utils_hline.setFrameShape(QFrame.Shape.HLine)
+        self.utils_hline.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_31.addWidget(self.utils_hline)
 
@@ -2139,8 +2141,8 @@ class Ui_main_window(object):
 
         self.utils_hline_2 = QFrame(self.file_setup_group_box)
         self.utils_hline_2.setObjectName(u"utils_hline_2")
-        self.utils_hline_2.setFrameShape(QFrame.HLine)
-        self.utils_hline_2.setFrameShadow(QFrame.Sunken)
+        self.utils_hline_2.setFrameShape(QFrame.Shape.HLine)
+        self.utils_hline_2.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_31.addWidget(self.utils_hline_2)
 
@@ -2174,8 +2176,8 @@ class Ui_main_window(object):
 
         self.utils_hline_3 = QFrame(self.file_setup_group_box)
         self.utils_hline_3.setObjectName(u"utils_hline_3")
-        self.utils_hline_3.setFrameShape(QFrame.HLine)
-        self.utils_hline_3.setFrameShadow(QFrame.Sunken)
+        self.utils_hline_3.setFrameShape(QFrame.Shape.HLine)
+        self.utils_hline_3.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_31.addWidget(self.utils_hline_3)
 
@@ -2701,7 +2703,7 @@ class Ui_main_window(object):
 
         self.retranslateUi(main_window)
 
-        self.tab_widget.setCurrentIndex(7)
+        self.tab_widget.setCurrentIndex(3)
 
 
         QMetaObject.connectSlotsByName(main_window)


### PR DESCRIPTION
## What does this PR do?
Comments out any Beedle Shop locations and also sets param1 of all `ShpSmpl` objects in Beedle's Shop to just be 0xFFFFFFFF so that they're all sold out. These can be easily reversed whenever shop shuffle gets implemented.

## How do you test this changes?
I generated a seed and Beedle's Shop locations were not in the log. I entered Beedle's Shop and all the items were sold out signs.
