### PR TITLE
Fix spoiler log setting string

### DIFF
--- a/logic/spoiler_log.py
+++ b/logic/spoiler_log.py
@@ -1,7 +1,8 @@
+from logic.config import load_config_from_file
 from randomizer.setting_string import setting_string_from_config
 from .world import *
 from .entrance_shuffle import create_entrance_pools
-from filepathconstants import SPOILER_LOGS_PATH
+from filepathconstants import CONFIG_PATH, SPOILER_LOGS_PATH
 from constants.randoconstants import VERSION
 import os
 
@@ -30,8 +31,12 @@ def spoiler_format_entrance(entrance: Entrance, longest_name_length: int) -> str
 def log_basic_info(log, config: Config, worlds: list[World]) -> None:
     log.write(f"Skyward Sword HD Randomizer Version: {VERSION}\n")
     log.write(f"Seed: {config.seed}\n")
+
+    clean_config = load_config_from_file(
+        CONFIG_PATH, allow_rewrite=False, create_if_blank=True
+    )
     log.write(
-        f"Setting String: {setting_string_from_config(config, worlds[0].location_table)}\n"
+        f"Setting String: {setting_string_from_config(clean_config, worlds[0].location_table)}\n"
     )
     log.write(f"Hash: {config.get_hash()}\n")
 


### PR DESCRIPTION
## What does this PR do?
Ensures the setting string given in the spoiler log correctly encodes settings set to random instead of using their evaluated values

## How do you test this changes?
I tested genning a seed before the change and pasting in the setting string from the generated spoiler log didn't give the same hash and the random settings were removed in favour of the values chosen during generation. I tested the same thing with the change and I got the same hash and the settings were all correct - including those set to random :p