### PR TITLE
Fix Path calculation edge case

### DIFF
--- a/logic/hints.py
+++ b/logic/hints.py
@@ -142,7 +142,10 @@ def calculate_possible_path_locations(worlds: list[World]) -> None:
                 world.path_locations[dungeon.goal_location] = []
 
         for location in world.location_table.values():
-            if not location.progression:
+            if not location.progression and not (
+                location.has_known_vanilla_item
+                and location.current_item.name == GRATITUDE_CRYSTAL
+            ):
                 non_required_locations[location] = location.current_item
                 location.remove_current_item()
 


### PR DESCRIPTION
## What does this PR do?
When calculating path hints, known vanilla gratitude crystals were getting temporarily taken away which resulted in any goal locations requiring known vanilla crystals to have every playthrough location on its path. This

## How do you test this changes?
I generated a few seeds with known vanilla single crystals and didn't see any wrong path calculations.

## Notes
This is more of a temporary fix. Ideally I'd like to rework single crystals so that we can both have them be unshuffled and excluded at the same time, but at this point we'll wait until after release for that.
