### PR TITLE
Fix some platform/GUI issues

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -66,7 +66,9 @@ class Main(QMainWindow):
         self.fi_info_dialog = FiInfoDialog(self)
         self.fi_question_dialog = FiQuestionDialog(self)
 
-        self.config = load_config_from_file(CONFIG_PATH, create_if_blank=True)
+        self.config = load_config_from_file(
+            CONFIG_PATH, create_if_blank=True, default_on_invalid_value=True
+        )
 
         print_progress_text("Initializing GUI: accessibility")
         self.accessibility = Accessibility(self, self.ui)

--- a/logic/config.py
+++ b/logic/config.py
@@ -196,7 +196,10 @@ def load_or_get_default_from_config(config: dict, setting_name: str):
 
 
 def load_config_from_file(
-    filepath: Path, allow_rewrite: bool = True, create_if_blank: bool = False
+    filepath: Path,
+    allow_rewrite: bool = True,
+    create_if_blank: bool = False,
+    default_on_invalid_value: bool = False,
 ) -> Config:
     if create_if_blank and not filepath.is_file():
         print("No config file found. Creating default config file.")
@@ -258,9 +261,17 @@ def load_config_from_file(
                     setting_value = config_in[world_num_str][setting_name]
 
                     if setting_value not in settings_info[setting_name].options:
-                        raise ConfigError(
-                            f'"{setting_value}" is not a valid value for setting "{setting_name}"'
-                        )
+                        if default_on_invalid_value:
+                            rewrite_config = True
+                            default_value = info.options[info.default_option_index]
+                            print(
+                                f'"{setting_value}" is not a valid value for setting "{setting_name}". Defaulting to "{default_value}"'
+                            )
+                            setting_value = default_value
+                        else:
+                            raise ConfigError(
+                                f'"{setting_value}" is not a valid value for setting "{setting_name}"'
+                            )
 
                     cur_world_settings.settings[setting_name] = Setting(
                         setting_name, setting_value, settings_info[setting_name]


### PR DESCRIPTION
## What does this PR do?
- Fixes Spinbox margins on windows 11
- Fixes the GUI becoming unresponsive on mac after showing full descriptions of a setting
- Fixes the GUI erroring out on updates that change setting options

## How do you test this changes?
I opened the GUI on Windows and Mac and everything worked as expected

## Notes
The issue on Mac was that the context menu event would trigger when pressing down the right mouse button. But for some reason the main GUI never registered that the right mouse button had been released and so it was basing its interactions as if the user was holding down right click (doing another right click and release on a blank part of the GUI would fix it). So I changed the event to check for releasing the right mouse button before showing the full setting description.
