### PR TITLE
Tooltip fix for real this time

### DIFF
--- a/constants/guiconstants.py
+++ b/constants/guiconstants.py
@@ -1,3 +1,5 @@
+from PySide6 import QtCore
+
 OPTION_PREFIX = "&nbsp;&nbsp;➜ "
 
 DEFAULT_PRESET = "~~ New Preset ~~"
@@ -38,4 +40,10 @@ LOCATION_FILTER_TYPES = (
     "Chests",
     "NPC",
     "Defeat Boss",
+)
+
+TRACKER_TOOLTIP_STYLESHEET = (
+    "QToolTip { color: black; background-color: white; border-image: none; border-color: white; "
+    + f"qproperty-alignment: {int(QtCore.Qt.AlignmentFlag.AlignCenter)};"
+    + " }"
 )

--- a/gui/components/tracker_area.py
+++ b/gui/components/tracker_area.py
@@ -3,6 +3,7 @@ from PySide6.QtGui import QCursor, QMouseEvent
 from PySide6 import QtCore
 from PySide6.QtCore import QEvent, QPoint, Signal
 
+from constants.guiconstants import TRACKER_TOOLTIP_STYLESHEET
 from logic.search import Search
 from logic.location import Location
 from logic.entrance import Entrance
@@ -23,11 +24,6 @@ class TrackerArea(QLabel):
         "QLabel { "
         + f"background-color: COLOR; border-image: none; background-image: none; border-color: black; border-radius: RADIUSpx; color: black; qproperty-alignment: {int(QtCore.Qt.AlignmentFlag.AlignCenter)};"
         + " }\n"
-    )
-    tooltip_stylesheet = (
-        "QToolTip { color: black; background-color: white; border-image: none; border-color: white; "
-        + f"qproperty-alignment: {int(QtCore.Qt.AlignmentFlag.AlignCenter)};"
-        + " }"
     )
 
     def __init__(
@@ -212,7 +208,7 @@ class TrackerArea(QLabel):
     def update_color(self, color: str) -> None:
         stylesheet = TrackerArea.default_stylesheet.replace("COLOR", color)
         stylesheet = stylesheet.replace("RADIUS", self.border_radius)
-        stylesheet = stylesheet + TrackerArea.tooltip_stylesheet
+        stylesheet = stylesheet + TRACKER_TOOLTIP_STYLESHEET
         self.setStyleSheet(stylesheet)
 
     def get_hint_tooltip_text(self) -> str:

--- a/gui/components/tracker_inventory_button.py
+++ b/gui/components/tracker_inventory_button.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import QEvent, QPoint, Signal
 
 
 from filepathconstants import TRACKER_ASSETS_PATH
+from constants.guiconstants import TRACKER_TOOLTIP_STYLESHEET
 
 from logic.world import World, Counter, Location
 from logic.item import Item
@@ -49,7 +50,9 @@ class TrackerInventoryButton(QLabel):
         self.state: int = 0
         self.pixmap = QPixmap()
         self.setCursor(QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
-        self.setStyleSheet("QLabel {background-color: rgba(0, 0, 0, 0);}")
+        self.setStyleSheet(
+            "QLabel {background-color: rgba(0, 0, 0, 0);}" + TRACKER_TOOLTIP_STYLESHEET
+        )
         self.update_icon()
         self.setMouseTracking(True)
         self.tooltip = ""

--- a/gui/components/tracker_toggle_st_button.py
+++ b/gui/components/tracker_toggle_st_button.py
@@ -2,6 +2,7 @@ from PySide6.QtWidgets import QPushButton, QToolTip
 from PySide6.QtGui import QCursor, QMouseEvent
 from PySide6 import QtCore
 from PySide6.QtCore import Signal, QPoint
+from constants.guiconstants import TRACKER_TOOLTIP_STYLESHEET
 
 
 class TrackerToggleSTButton(QPushButton):
@@ -14,6 +15,7 @@ class TrackerToggleSTButton(QPushButton):
         self.setText("Enable Sphere Tracking")
         self.setCursor(QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
         self.setMouseTracking(True)
+        self.setStyleSheet(TRACKER_TOOLTIP_STYLESHEET)
 
     def mouseMoveEvent(self, ev: QMouseEvent) -> None:
         coords = self.mapToGlobal(QPoint(0, 0)) + QPoint(100, int(self.height() / 4))

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -1658,9 +1658,8 @@ class Tracker:
                 if inventory[item] > 0:
                     inventory[item] -= 1
 
-        sphere_search = Search(
-            SearchMode.TRACKER_SPHERES, [self.world], list(inventory)
-        )
+        # TODO: Fix weird typing
+        sphere_search = Search(SearchMode.TRACKER_SPHERES, [self.world], inventory)
         sphere_search.search_worlds()
         for num, sphere in enumerate(sphere_search.playthrough_spheres):
             for loc in sphere:


### PR DESCRIPTION
## What does this PR do?
Adds a consistent tooltip stylesheet with black text and white background to all tracker components that use it. Also removes the list conversion for the sphere calculation function's inventory, fixing the issue that broke sphere tracking.

## How do you test this changes?
I've verified that it looks correct on MacOS, and Esme has confirmed it looks correct on Windows.

## Notes
QT sucks.
