### PR TITLE
Fix some bottle things

### DIFF
--- a/data/items.yaml
+++ b/data/items.yaml
@@ -504,7 +504,7 @@
     - Bottles
     - Major Items
     - Side Quest Items
-  oarc: GetBottleKusuriS
+  oarc: GetBottleKusuri
   advancement: true
 - id: 81
   name: Heart Potion Plus Plus
@@ -783,7 +783,7 @@
     - Bottles
     - Major Items
     - Side Quest Items
-  oarc: GetBottleRepairS
+  oarc: GetBottleRepair
   advancement: true
 - id: 128
   name: Small Seed Satchel

--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -62,7 +62,7 @@
   standard: "You learned the <y<final part of the\nSong of the Hero>>...\n\n\nThe <y<Song of the Hero>> is now complete!"
 
 - name: Cold Pumpkin Soup text
-  standard: "You got some <y<Cold Pumpkin Soup>>!\nThis homemade soup is Pumm's specialty,\nbut someone's get it get cold..."
+  standard: "You got some <y<Cold Pumpkin Soup>>!\nThis homemade soup is Pumm's specialty,\nbut someone's let it get cold..."
 
 - name: Five Gratitude crystal counter
   standard: "You got <r<five>> <y<Gratitude Crystals>>!\nThat is <r<<numeric arg1> >>in total!"


### PR DESCRIPTION
## What does this PR do?
Fixes the oarc names for Heart Potion Plus and Revitalizing Potion Plus. Also fixes a typo in the get item text for cold soup.

## How do you test this changes?
I plandomized each bottle item to the same freestanding location and all worked as expected. 
