### PR TITLE
Hide check-all buttons when Start New Tracker is clicked

### DIFF
--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -665,6 +665,12 @@ class Tracker:
         for area in self.areas.values():
             area.hints.clear()
 
+        # Re-hide the check/uncheck all buttons
+        self.ui.check_all_button.setVisible(False)
+        self.ui.check_all_in_logic_button.setVisible(False)
+        self.ui.uncheck_all_button.setVisible(False)
+        self.ui.set_hints_button.setVisible(False)
+
         # Modify settings for various purposes
 
         # Don't include random starting items in the tracker world


### PR DESCRIPTION
## What does this PR do?
Title.

## How do you test this changes?
I started a new tracker with a region's checks open, and the buttons disappeared.

## Notes
Before, these buttons would stay visible and clicking on them would result in an AssertionError.
