### PR TITLE
Update default options for open ET and Batreaux's Shed

### DIFF
--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -984,7 +984,7 @@
 
 - name: open_earth_temple
   tracker_important: true
-  default_option: "off"
+  default_option: "on"
   pretty_name: Open Earth Temple
   pretty_options:
     - "Off"
@@ -1008,7 +1008,7 @@
 
 - name: open_batreaux_shed
   tracker_important: true
-  default_option: "off"
+  default_option: "on"
   pretty_name: Open Batreaux's Shed
   pretty_options:
     - "Off"


### PR DESCRIPTION
## What does this PR do?
Just changes the default value for both of these shortcuts from off to on