### PR TITLE
Fix health traps

### DIFF
--- a/constants/itemconstants.py
+++ b/constants/itemconstants.py
@@ -520,4 +520,5 @@ TRAP_SETTING_TO_ITEM = {
     "curse_traps": CURSE_TRAP,
     "noise_traps": NOISE_TRAP,
     "groose_traps": GROOSE_TRAP,
+    "health_traps": HEALTH_TRAP,
 }

--- a/constants/itemnames.py
+++ b/constants/itemnames.py
@@ -714,6 +714,7 @@ SCRAPPER = "Scrapper"
 # 249
 
 # 250
+HEALTH_TRAP = "Health " + TRAP
 
 # 251
 GROOSE_TRAP = "Groose " + TRAP


### PR DESCRIPTION
## What does this PR do?
Fixes an issue where Health Traps would never be placed by the fill algorithm unless plandomized to do so

## How do you test this changes?
I generated a seed with `trap_mode` set to `traptacular` before the change and no Health Traps were placed. After the change, the same seed was mostly filled with Health Traps as expected :p