### PR TITLE
Raise a better error when generation fails to fill dungeon goal locations

### DIFF
--- a/logic/fill.py
+++ b/logic/fill.py
@@ -214,8 +214,12 @@ def fill_required_dungeon_goal_locations(world: World, worlds: list[World]):
             goal_location_items.append(triforce_pieces.pop())
         elif len(swords) > 0:
             goal_location_items.append(swords.pop())
-        else:
+        elif len(major_items) > 0:
             goal_location_items.append(major_items.pop())
+        else:
+            raise FillError(
+                "Could not generate a seed because there are no more items left to make enough required dungeons.\nThis could be because the current settings start with too many items."
+            )
 
         # Then take it out of the world's item pool
         world.item_pool[goal_location_items[-1]] -= 1


### PR DESCRIPTION
## What does this PR do?
Raise an explicit error when generation fails to place major items on the required dungeon goal locations.

## How do you test this changes?
I generated a seed that previously gave an error of:
`IndexError: pop from empty list`.

It instead gave this error:
```
logic.fill.FillError: Could not generate a seed because there are no more items left to make enough required dungeons.
This could be because the current settings start with too many items.
```