### PR TITLE
Add one-time info text to randomization complete popup

### DIFF
--- a/constants/configconstants.py
+++ b/constants/configconstants.py
@@ -35,6 +35,7 @@ PREFERENCE_FIELDS = (
     "font_size",
     "verified_extract",
     "tutorial_random_settings",
+    "first_time_seed_gen_text",
 )
 
 
@@ -62,6 +63,7 @@ DEFAULT_SETTINGS = {
     "font_size": 10,
     "verified_extract": False,
     "tutorial_random_settings": False,
+    "first_time_seed_gen_text": False,
     "starting_inventory": Counter(
         [
             HYLIAN_SHIELD,

--- a/gui/main.py
+++ b/gui/main.py
@@ -102,9 +102,14 @@ class Main(QMainWindow):
 
         done_dialog = QMessageBox(self)
         done_dialog.setWindowTitle("Randomization Completed")
-        done_dialog.setText(
+        done_dialog_text = (
             f"Seed successfully generated!\n\nHash: {self.config.get_hash()}"
         )
+
+        if not self.config.first_time_seed_gen_text:
+            done_dialog_text += "\n\nPlease note that the item which spawns after defeating a boss will always look like a Heart Container. This item is actually randomized even though it doesn't look different and could be a useful item.\n\nAlso, the Tablets shown in the inventory screen do not accurately show which Tablet items you currently have. You will need to look at which light pillars are glowing in The Sky to know for sure which Tablets you currently have."
+
+        done_dialog.setText(done_dialog_text)
 
         open_output_button = done_dialog.addButton(
             "Open", QMessageBox.ButtonRole.NoRole
@@ -122,6 +127,9 @@ class Main(QMainWindow):
         )
         done_dialog.setIconPixmap(icon_pixmap)
         done_dialog.exec()
+
+        self.config.first_time_seed_gen_text = True
+        write_config_to_file(CONFIG_PATH, self.config)
 
         # Prevents old progress dialogs reappearing when generating another
         # seed without reopening the entire program


### PR DESCRIPTION
## What does this address?
Adds some explainer text onto the completion popup after generating a seed. The text explains how the heart container which spawns after defeating a boss doesn't look like a randomized item even though it is one. It also explains how the Tablets in the inventory screen don't accurately show which Tablets the player has and explains how to get this info.

This is the text:
![image](https://github.com/mint-choc-chip-skyblade/sshd-rando/assets/84377742/a90f8488-348e-482f-8b14-fd034614cc7c)


## How did/do you test these changes?
* I generated a seed and the extra text was visible
* I generated the same seed again and the text wasn't there
* I closed and re-opened the randomizer program, generated the same seed again and the text wasn't there
* I reset the variable which controls the text. I generated a seed (and got the text). I then clicked the "New Seed" button and generated a new seed and did not get the text