### PR TITLE
Fix tracker asset typo causing errors on linux

### DIFF
--- a/gui/components/tracker_inventory_button.py
+++ b/gui/components/tracker_inventory_button.py
@@ -67,6 +67,9 @@ class TrackerInventoryButton(QLabel):
             f"{(TRACKER_ASSETS_PATH / self.filenames[self.state]).as_posix()}"
         ):
             print(f"Could not load pixmap for {self.items[-1]}")
+            print(
+                f"File: {(TRACKER_ASSETS_PATH / self.filenames[self.state]).as_posix()}"
+            )
 
         self.update()  # Calls paintEvent
 

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -498,7 +498,7 @@ class Tracker:
         # )
         self.scrapper_button = TrackerInventoryButton(
             ["Nothing", SCRAPPER],
-            ["main quest/scrapper_gray.png", "main quest/scrapper.png"],
+            ["main quest/scrapper_gray.png", "main quest/Scrapper.png"],
         )
 
         # Load in tracker area buttons


### PR DESCRIPTION
## What does this address?

Fixes this issue that shows up on linux:
```
Could not load pixmap for Scrapper
Traceback (most recent call last):
  File "gui/components/tracker_inventory_button.py", line 80, in paintEvent
ZeroDivisionError: division by zero
Qt caught and ignored exception:


<class 'ZeroDivisionError'>: division by zero
QBackingStore::endPaint() called with active painter; did you forget to destroy it or call QPainter::end() on it?
```


## How did/do you test these changes?
I loaded a new tracker on linux and the error stopped happening

## Notes
Windows isn't case-sensitive so it doesn't have the error
