### PR TITLE
Not show tracker entrance selection for unrandomized entrance types

### DIFF
--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -1136,6 +1136,10 @@ class Tracker:
     def show_target_selection_info(
         self, entrance: Entrance, parent_area_name: str = ""
     ) -> None:
+        # Don't show entrance stuff if the entrance type isn't randomized
+        if entrance.type not in self.target_entrance_pools:
+            return
+
         self.clear_layout(self.ui.tracker_locations_info_layout)
 
         # Layouts used for the info area


### PR DESCRIPTION
## What does this address?
Fixes the following issue when you right-click to set an entrance that has an entrance type that isn't randomized

```
Traceback (most recent call last):
  File "C:\Users\Esme\Documents\00-Documents\nintendo\rando\sshd\sshdr\gui\tracker.py", line 1172, in show_target_selection_info
    targets = self.target_entrance_pools[entrance.type]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'Faron Region Entrance'
Qt caught and ignored exception:


<class 'KeyError'>: 'Faron Region Entrance'
```


## How did/do you test these changes?
Right-clicking entrances that aren't of a type that's randomized does nothing. Using the Beginner preset previously gave this error: `U1NIRFItMS4wADEAU3RhZ0JlYW1vc0x1bXB5WmVsZGEAOleIABAAsgRGbmgRAAAoUEAAFiMAkBEAFBBBABQAAAAAAAAAAACAAgKAAAAgAAAAQAAAAACAAwAD0AEABAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJIgAACgAAAEEAAD8gbYt`