### PR TITLE
Fix a bunch of logic things

### DIFF
--- a/constants/itemconstants.py
+++ b/constants/itemconstants.py
@@ -113,6 +113,7 @@ ITEMS_NOT_TO_TRAP = (
 
 # Item Pools
 ALL_JUNK_ITEMS: list[str] = [
+    MONSTER_HORN,
     GOLDEN_SKULL,
     GODDESS_PLUME,
     DUSK_RELIC,

--- a/data/entrance_shuffle_data.yaml
+++ b/data/entrance_shuffle_data.yaml
@@ -111,6 +111,10 @@
         entrance: 0
   return:
     connection: LMF First Room -> Top of LMF
+    # Conditional connections may only stay if the above connection
+    # is vanilla
+    conditional_vanilla_connections:
+     - LMF End of Hall of Ancient Robots -> Temple of Time West Post LMF Area
     exit_infos:
       - stage: D300
         room: 0

--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -5,7 +5,13 @@
     Sealed Grounds Statue: Nothing
     Sealed Grounds Spiral: Nothing
     Sealed Grounds Upper Ledge: shortcut_spiral_log_to_btt or 'Push_Down_Sealed_Grounds_Log'
-    # Groosenator
+    Sealed Grounds Groosenator: Nothing
+  locations:
+    Sealed Grounds - Bonk Wall between Pillars near Bird Statue: Nothing
+
+- name: Sealed Grounds Groosenator
+  hint_region: None # Don't allow sealed grounds to be the parent area of any areas reached with the groosenator
+  exits:
     Flooded Faron Woods: Nothing
     Fun Fun Island: unlock_all_groosenator_destinations
     Bug Heaven: unlock_all_groosenator_destinations
@@ -14,8 +20,6 @@
     Lanayru Gorge: unlock_all_groosenator_destinations
     Shipyard Dock: unlock_all_groosenator_destinations
     Outside Thrill Digger Cave: unlock_all_groosenator_destinations
-  locations:
-    Sealed Grounds - Bonk Wall between Pillars near Bird Statue: Nothing
 
 - name: Sealed Grounds Spiral
   hint_region: Sealed Grounds

--- a/logic/entrance.py
+++ b/logic/entrance.py
@@ -70,6 +70,9 @@ class Entrance:
         # Only potentially shuffled entrances will have a sort priority set
         self.sort_priority: int = 0
 
+        # Additional Entrances that can only be allowed if this entrance is vanilla
+        self.conditional_vanilla_connections: list["Entrance"] = []
+
     def __str__(self) -> str:
         return self.original_name
 
@@ -91,11 +94,16 @@ class Entrance:
     def connect(self, new_connected_area: "Area") -> None:
         self.connected_area = new_connected_area
         new_connected_area.entrances.append(self)
+        if new_connected_area == self.original_connected_area:
+            for entrance in self.conditional_vanilla_connections:
+                entrance.connect(entrance.original_connected_area)
 
     def disconnect(self) -> "Area":
         self.connected_area.entrances.remove(self)
         previously_connected = self.connected_area
         self.connected_area = None
+        for entrance in self.conditional_vanilla_connections:
+            entrance.disconnect()
         return previously_connected
 
     def bind_two_way(self, return_entrance: "Entrance") -> None:

--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -119,6 +119,12 @@ def set_all_entrances_data(world: World) -> None:
             )
             forward_entrance.primary = True
             forward_entrance.sort_priority = Entrance.sort_counter
+            if conditional_vanilla_connections := entrance_data["forward"].get(
+                "conditional_vanilla_connections", None
+            ):
+                forward_entrance.conditional_vanilla_connections.extend(
+                    [world.get_entrance(e) for e in conditional_vanilla_connections]
+                )
             Entrance.sort_counter += 1
             if return_entrance != None:
                 return_entrance.type = entrance_type
@@ -140,6 +146,12 @@ def set_all_entrances_data(world: World) -> None:
                 )
                 return_entrance.sort_priority = Entrance.sort_counter
                 Entrance.sort_counter += 1
+                if conditional_vanilla_connections := entrance_data["return"].get(
+                    "conditional_vanilla_connections", None
+                ):
+                    return_entrance.conditional_vanilla_connections.extend(
+                        [world.get_entrance(e) for e in conditional_vanilla_connections]
+                    )
                 forward_entrance.bind_two_way(return_entrance)
 
         # If double doors are to be coupled, add the coupled door's

--- a/logic/fill.py
+++ b/logic/fill.py
@@ -190,7 +190,7 @@ def fill_required_dungeon_goal_locations(world: World, worlds: list[World]):
     # Get all required goal locations
     required_goal_locations = []
     for dungeon in world.dungeons.values():
-        if dungeon.required:
+        if dungeon.required and dungeon.goal_location.is_empty():
             required_goal_locations.append(dungeon.goal_location)
 
     # Return early if there are no goal locations

--- a/logic/world.py
+++ b/logic/world.py
@@ -242,9 +242,10 @@ class World:
                             )
                             # Add the location to the dungeon if this area is part of one
                             if dungeon_name := area_node.get("dungeon", False):
-                                self.get_dungeon(dungeon_name).locations.append(
-                                    self.get_location(location_name)
-                                )
+                                dungeon = self.get_dungeon(dungeon_name)
+                                location = self.get_location(location_name)
+                                if location not in dungeon.locations:
+                                    dungeon.locations.append(location)
 
                     if "exits" in area_node:
                         for connected_area_name, req_str in area_node["exits"].items():

--- a/logic/world.py
+++ b/logic/world.py
@@ -448,14 +448,17 @@ class World:
                         f"Dungeon {dungeon.name} is required to go through, but has a junk goal location. Either roll a new seed or change your plandomizer to allow this dungeon to be required."
                     )
                 dungeons.remove(dungeon)
-            elif not dungeon.starting_entrance.disabled or any(
-                [
-                    loc
-                    for loc in dungeon.locations
-                    if not loc.is_empty()
-                    and loc.current_item.is_major_item
-                    and not loc.has_known_vanilla_item
-                ]
+            elif not dungeon.starting_entrance.disabled or (
+                any(
+                    [
+                        loc
+                        for loc in dungeon.locations
+                        if not loc.is_empty()
+                        and loc.current_item.is_major_item
+                        and not loc.has_known_vanilla_item
+                    ]
+                )
+                and self.setting("empty_unrequired_dungeons") == "on"
             ):
                 dungeon.required = True
                 num_required_dungeons -= 1
@@ -464,13 +467,16 @@ class World:
                     and self.setting("empty_unrequired_dungeons") == "on"
                 ):
                     raise WrongInfoError(
-                        "There are more major items plandomized at the end of dungeons than there are required dungeons. Please remove some plandomized major items at the end of dungeons"
+                        "There are more major items plandomized at the end of dungeons than there are required dungeons. Please remove some plandomized major items at the end of dungeons or disable Barren Unrequired Dungeons."
                     )
                 logging.getLogger("").debug(
                     f"Chose {dungeon} as force required dungeon"
                 )
 
-        if num_required_dungeons > len(dungeons):
+        if (
+            num_required_dungeons > len(dungeons)
+            and self.setting("empty_unrequired_dungeons") == "on"
+        ):
             raise WrongInfoError(
                 "Not enough free goal locations to satisfy required dungeons. Please remove junk that has been plandomized at the end of dungeons"
             )


### PR DESCRIPTION
## What does this address?
Fixes the following issues:
- Plandomizer making weird choices with required dungeons
- The tracker showing Shipyard locations in multiple areas
- The tracker not showing the Rupee Above Drawbridge location in Earth Temple if Barren Unrequired Dungeons was on
- The end of LMF always logically connecting to Temple of Time even when dungeon entrance rando is on

## How did/do you test these changes?
Tested each one individually and all seemed good.

## Notes
The end of LMF to ToT entrance will only be logically connected if exiting LMF is vanilla (regardless of if dungeon entrance rando is on or not).
