### PR TITLE
Fix tracker autosave on builds

### DIFF
--- a/filepathconstants.py
+++ b/filepathconstants.py
@@ -58,7 +58,7 @@ RANDO_FONT_PATH = RANDO_ROOT_PATH / "assets" / "Figtree-Regular.ttf"
 DYSLEXIC_FONT_PATH = RANDO_ROOT_PATH / "assets" / "OpenDyslexic3-Regular.ttf"
 
 TRACKER_AREAS_PATH = RANDO_ROOT_PATH / "data" / "tracker_areas.yaml"
-TRACKER_AUTOSAVE_PATH = RANDO_ROOT_PATH / "tracker_autosave_RANDOMIZER_VERSION.yaml"
+TRACKER_AUTOSAVE_PATH = Path(userdata_path) / "tracker_autosave_RANDOMIZER_VERSION.yaml"
 
 # Stage and event stuff
 OARC_CACHE_PATH = Path(userdata_path) / "oarccache"


### PR DESCRIPTION
## What does this address?
Running the randomizer program from a build seemingly wouldn't save the tracker_autosave file.

This issue was caused by using the root path of where the program was being executed from instead of the path to were the program files actually are. The autosave worked from source because these 2 locations are the same. On builds, the randomizer program actually gets run from a temp directory so the autosave file was being saved there - which would get deleted once the randomizer program was closed.


## How did/do you test these changes?
I created a build and saw the autosave file appear in the correct location after clicking the "Start New Tracker" button. I was able to close the randomizer program and re-open it without losing changes I had previously made to the tracker