### PR TITLE
Adjust right-click behavior for tracker areas

### DIFF
--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -1623,24 +1623,26 @@ class Tracker:
             location_list = self.last_opened_region.get_available_locations()
         else:
             location_list = self.last_opened_region.get_included_locations()
-        if check == False and self.allow_sphere_tracking:
-            # untrack all sphere-tracked items in this area
-            self.last_checked_location = None
-            for location in location_list:
-                if location.tracked_item is not None:
-                    del self.sphere_tracked_items[location]
-                    location.tracked_item = None
-                    location.tracked_item_image = None
-
-            # update the location list to remove the item images
-            self.show_area_locations(self.last_opened_region.area)
 
         self.check_all_locations_in_list(location_list, check)
         self.last_opened_region.update_hover_text()
 
     def check_all_locations_in_list(self, location_list: list[Location], check=True):
+        should_undo_sphere_tracking = check == False and self.allow_sphere_tracking
+
         for location in location_list:
             location.marked = check
+            if should_undo_sphere_tracking and location.tracked_item is not None:
+                # untrack sphere-tracked items
+                del self.sphere_tracked_items[location]
+                location.tracked_item = None
+                location.tracked_item_image = None
+
+        if should_undo_sphere_tracking:
+            self.last_checked_location = None
+            if self.last_opened_region is not None:
+                # update the location list to remove the item images
+                self.show_area_locations(self.last_opened_region.area)
         self.update_tracker()
 
     def update_hover_text(self, text: str):


### PR DESCRIPTION
## What does this address?

Partially addresses #338 (Point 3)

- Right clicking on an area with at least one (but not all) location accessible will now check all locations in logic
- Right clicking an area with all locations accessible or no locations accessible, but with at least one unmarked location will check all locations
- Right clicking an area with all locations marked will uncheck all locations

The area tooltip now displays which of these actions will be performed.


## How did/do you test these changes?
I have verified that the right-click actions and tooltips work as expected. Righ-clicking Knight Academy (at 2/6) will mark the 2 available locations. Right clicking it again will mark the 4 remaining locations. Right clicking it a third time will unmark all 6 locations.


## Notes
Just like the check-all, uncheck-all, and check-all in logic buttons, this excludes special locations like non-randomized gratitude crystals, gossip stones, and Goddess Cubes. The tooltip was also moved a bit to the left, since the average tooltip is now wider thanks to the right-click info text.
