### PR TITLE
Fix workflow issue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,8 @@ jobs:
         id: setup-py
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          # TODO: Unfreeze python version when this is resolved: https://github.com/actions/setup-python/issues/886
+          python-version: "3.12.3"
           check-latest: true
           architecture: ${{ matrix.architecture }}
           cache: "pip" # Cache all pip dependency downloads

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
         id: setup-py
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.12.3"
           check-latest: true
           cache: "pip" # Cache all pip dependency downloads
       - name: Cache venv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,7 @@ jobs:
         id: setup-py
         uses: actions/setup-python@v5
         with:
+          # TODO: Unfreeze python version when this is resolved: https://github.com/actions/setup-python/issues/886
           python-version: "3.12.3"
           check-latest: true
           cache: "pip" # Cache all pip dependency downloads


### PR DESCRIPTION
## What does this address?
This morning, runs of the `build.yaml` or `tests.yaml` workflows were erroring where when they were successful last night. A bit of digging seems to indicate that python 3.12.4 isn't playing nicely with `actions/setup-python`: https://github.com/actions/setup-python/issues/886

## How did/do you test these changes?
I changed the python version used from 3.12 to 3.12.3 and the workflows function correctly again. This is only be a temp fix and should be checked back in on

![image](https://github.com/mint-choc-chip-skyblade/sshd-rando/assets/84377742/883b091e-add0-444b-9cfe-469108172544)