### PR TITLE
Botg fixes

### DIFF
--- a/constants/itemconstants.py
+++ b/constants/itemconstants.py
@@ -442,7 +442,7 @@ ITEM_STORYFLAGS = {
     CLAWSHOTS: 208,  # Completed Lanayru Trial
     STONE_OF_TRIALS: (210, 209),  # Obtained SoT, Completed Hylia's Trial
     GODDESS_HARP: (9, 140),  # Harp, Watched Groose CS
-    BALLAD_OF_THE_GODDESS: 893,
+    BALLAD_OF_THE_GODDESS: 493,
     SONG_OF_THE_HERO: 369,
     TRIFORCE_OF_COURAGE: 729,
     TRIFORCE_OF_POWER: 728,

--- a/data/README.md
+++ b/data/README.md
@@ -11,7 +11,7 @@ Below is the list of all the flags that the randomizer changes:
 
 * 323: Repair Gondo's Junk Check (repurposed: "Learn about Scrapper near Village Windmill")
 
-* 893: Ballad of the Goddess item
+* 493: Ballad of the Goddess item / Unlocked Goddess Walls
 
 * 894: Should fill bottle not create new
 

--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -369,7 +369,7 @@
   - name: Give rando BotG storyflag
     type: setstoryflag
     flow:
-      setstoryflag: 893 # Rando storyflag for BotG item
+      setstoryflag: 493 # Unlocked Goddess Walls / BotG flag
       next: Check harp storyflag
   - name: Check harp storyflag
     type: checkstoryflag
@@ -429,7 +429,7 @@
   - name: Check BotG storyflag
     type: checkstoryflag
     flow:
-      checkstoryflag: 893
+      checkstoryflag: 493 # Unlocked Goddess Walls / BotG flag
     cases:
       - Set GoT raised
       - -1

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -60,6 +60,22 @@ F000: # Skyloft
     layer: 6
 
   # F000 objadds
+  - name: Light Tower SwHrp on layer 6
+    type: objadd
+    layer: 6
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xFF0F021D
+      params2: 0xFFFFFFFF
+      posx: 3040
+      posy: 2175
+      posz: 6084
+      anglex: 0
+      angley: 3276
+      anglez: 0
+      id: 0xFDC3
+      name: SwHrp
   - name: Horwell on layer 4
     type: objadd
     layer: 4

--- a/data/patches/startflags.yaml
+++ b/data/patches/startflags.yaml
@@ -29,7 +29,8 @@ Storyflags:
   - 329 # Slept after starting Batreaux Crystal Quest
   # - 358  # Interface choice unlocked
   - 386 # Skip first part of Bertie's Crystal Quest text
-  - 493 # Unlocked Goddess Walls
+  - Ballad_of_the_Goddess:
+    - 493 # Unlocked Goddess Walls
   - 494 # Open gates to Faron Woods
   - 496 # Skip Skipper's Cutscene after Sea Chart
   - 519 # Updated Sand Sea map


### PR DESCRIPTION
## What does this address?
Fixes the issue where you didn't need Ballad of the Goddess to activate Goddess Walls. Fixes the issue where you couldn't open The Thunderhead after placing the Stone of Trials.


## How did/do you test these changes?
I tested trying to activate Gorko's Goddess Wall when starting without either harp or ballad, only starting with one of them, or starting with both.

I tested placing the Stone of Trials and then opening The Thunderhead on top of the light tower.