### PR TITLE
Decrease Hint Text Maximum Line Length

### DIFF
--- a/util/text.py
+++ b/util/text.py
@@ -305,7 +305,7 @@ def break_lines(text: str) -> str:
         "!": 7,
     }
 
-    max_line_length = 700
+    max_line_length = 695
     cur_line_width = 0
 
     i = 0


### PR DESCRIPTION
## What does this address?
Decreases the maximum line length of a hint from 700 to 695 pixels. This fixes the edge case of the person who generated a hint that was formatted weirdly. 

## How did/do you test these changes?
I generated the same hint and it was formatted correctly.

## Notes
I'm not sure what the exact maximum line length is in game, but it's fine if we're short a few pixels. I don't think anyone will care.
