### PR TITLE
Move caged robot NpcTke on top of robot

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -3344,6 +3344,16 @@ F300: # Lanayru Desert
     layer: 0
     room: 0
     objtype: STAG
+  - name: Move caged robot NpcTke
+    type: objpatch
+    id: 0xFC50
+    layer: 0
+    room: 0
+    objtype: OBJ
+    object:
+      posx: 450
+      posy: -40
+      posz: 8192
 
   - name: Chest Spawns after LMF
     type: objpatch


### PR DESCRIPTION
## What does this address?
Fixes a bug where, if a trap spawns Groose near the caged robot, then you could get the check without having to kill the technoblins.


## How did/do you test these changes?
I spawned Groose in the area that would cause the bug and tried to collect the check. I was only able to get the check from the robot after I had defeated the technoblins