### PR TITLE
Add logic for ringing the academy bell with bellows

### DIFF
--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -123,7 +123,7 @@
   locations:
     Upper Skyloft - Owlan's Gift: Day
     Upper Skyloft - Rescue Remlit above Knight Academy: Day
-    Upper Skyloft - Ring Knight Academy Bell: Distance_Activator or (Bomb_Bag and logic_bomb_throws)
+    Upper Skyloft - Ring Knight Academy Bell: Distance_Activator or Gust_Bellows or (Bomb_Bag and logic_bomb_throws)
     Upper Skyloft - Slingshot Left Lamp outside Upper Academy Doors: Slingshot
     Upper Skyloft - Slingshot Right Lamp outside Upper Academy Doors: Slingshot
     Upper Skyloft - Slingshot Left Lamp outside Sparring Hall Doors: Slingshot


### PR DESCRIPTION
## What does this address?
Turns out you can get the `Upper Skyloft - Ring Knight Academy Bell` check by blowing the Gust Bellows at it :p
