### PR TITLE
Rename confusing blow robot checks

### DIFF
--- a/constants/configconstants.py
+++ b/constants/configconstants.py
@@ -145,6 +145,13 @@ LOCATION_ALIASES = {
     "Temple of Time - Bonk Northeast Pillar": "Temple of Time - Bonk Northeast Bird Pillar near Gate of Time",
     "Temple of Time - Bonk Southeast Pillar": "Temple of Time - Bonk Southeast Bird Pillar near Gate of Time",
     "Sealed Grounds - Blow Bushes in Corner Left of Gossip Stone": "Sealed Grounds - Blow High Bushes in Corner Left of Gossip Stone",
+    "Lanayru Mine - Blow Digging Robot before Side Room near First Timeshift Stone": "Lanayru Mine - Blow Digging Robot's Wall before Side Room near First Timeshift Stone",
+    "Lanayru Mine - Blow Left Digging Robot in Side Room near First Timeshift Stone": "Lanayru Mine - Blow Left Digging Robot's Wall in Side Room near First Timeshift Stone",
+    "Lanayru Mine - Blow Right Digging Robot in Side Room near First Timeshift Stone": "Lanayru Mine - Blow Right Digging Robot's Wall in Side Room near First Timeshift Stone",
+    "Lanayru Mine - Blow Left Digging Robot after First Minecart Ride": "Lanayru Mine - Blow Left Digging Robot's Wall after First Minecart Ride",
+    "Lanayru Mine - Blow Right Digging Robot after First Minecart Ride": "Lanayru Mine - Blow Right Digging Robot's Wall after First Minecart Ride",
+    "Lanayru Mine - Blow Digging Robot near Mine Exit": "Lanayru Mine - Blow Digging Robot's Wall near Mine Exit",
+    "Lanayru Mine - Blow Digging Robot near Last Mine Timeshift Stone": "Lanayru Mine - Blow Digging Robot's Wall near Last Mine Timeshift Stone",
 }
 
 SETTING_ALIASES = {

--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -4114,7 +4114,7 @@
   Paths:
     - stage/F300_1/r0/l0/TBox/64
 
-- name: Lanayru Mine - Blow Digging Robot before Side Room near First Timeshift Stone
+- name: Lanayru Mine - Blow Digging Robot's Wall before Side Room near First Timeshift Stone
   original_item: Blue Rupee
   types:
     - Hidden Items
@@ -4122,7 +4122,7 @@
   Paths:
     - stage/F300_1/r0/l0/TgReact/0xFC57
 
-- name: Lanayru Mine - Blow Left Digging Robot in Side Room near First Timeshift Stone
+- name: Lanayru Mine - Blow Left Digging Robot's Wall in Side Room near First Timeshift Stone
   original_item: Blue Rupee
   types:
     - Hidden Items
@@ -4130,7 +4130,7 @@
   Paths:
     - stage/F300_1/r1/l0/TgReact/0xFC07
 
-- name: Lanayru Mine - Blow Right Digging Robot in Side Room near First Timeshift Stone
+- name: Lanayru Mine - Blow Right Digging Robot's Wall in Side Room near First Timeshift Stone
   original_item: Blue Rupee
   types:
     - Hidden Items
@@ -4197,7 +4197,7 @@
   Paths:
     - stage/F300_1/r0/l0/TgReact/0xFC56
 
-- name: Lanayru Mine - Blow Left Digging Robot after First Minecart Ride
+- name: Lanayru Mine - Blow Left Digging Robot's Wall after First Minecart Ride
   original_item: Blue Rupee
   types:
     - Hidden Items
@@ -4205,7 +4205,7 @@
   Paths:
     - stage/F300_1/r2/l0/TgReact/0xFC60
 
-- name: Lanayru Mine - Blow Right Digging Robot after First Minecart Ride
+- name: Lanayru Mine - Blow Right Digging Robot's Wall after First Minecart Ride
   original_item: Blue Rupee
   types:
     - Hidden Items
@@ -4278,7 +4278,7 @@
   Paths:
     - stage/F300_1/r2/l0/Item/0xFC1C
 
-- name: Lanayru Mine - Blow Digging Robot near Mine Exit
+- name: Lanayru Mine - Blow Digging Robot's Wall near Mine Exit
   original_item: Blue Rupee
   types:
     - Hidden Items
@@ -4286,7 +4286,7 @@
   Paths:
     - stage/F300_1/r2/l0/TgReact/0xFC6F
 
-- name: Lanayru Mine - Blow Digging Robot near Last Mine Timeshift Stone
+- name: Lanayru Mine - Blow Digging Robot's Wall near Last Mine Timeshift Stone
   original_item: Blue Rupee
   types:
     - Hidden Items

--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -3818,19 +3818,19 @@
   pretty: Lanayru Mine - Chest behind First Landing Robot
   cryptic: a <r<chest at the entry to a mine>>
 
-- name: Lanayru Mine - Blow Digging Robot before Side Room near First Timeshift Stone
-  standard: Lanayru Mine - Blow Digging Robot before Side Room near First Timeshift Stone
-  pretty: Lanayru Mine - Blow Digging Robot before Side Room near First Timeshift Stone
+- name: Lanayru Mine - Blow Digging Robot's Wall before Side Room near First Timeshift Stone
+  standard: Lanayru Mine - Blow Digging Robot's Wall before Side Room near First Timeshift Stone
+  pretty: Lanayru Mine - Blow Digging Robot's Wall before Side Room near First Timeshift Stone
   cryptic: <r<dusting a worker>> near a <y<large time distortion>>
 
-- name: Lanayru Mine - Blow Left Digging Robot in Side Room near First Timeshift Stone
-  standard: Lanayru Mine - Blow Left Digging Robot in Side Room near First Timeshift Stone
-  pretty: Lanayru Mine - Blow Left Digging Robot in Side Room near First Timeshift Stone
+- name: Lanayru Mine - Blow Left Digging Robot's Wall in Side Room near First Timeshift Stone
+  standard: Lanayru Mine - Blow Left Digging Robot's Wall in Side Room near First Timeshift Stone
+  pretty: Lanayru Mine - Blow Left Digging Robot's Wall in Side Room near First Timeshift Stone
   cryptic: <r<dusting a worker>> near a <y<large time distortion>>
 
-- name: Lanayru Mine - Blow Right Digging Robot in Side Room near First Timeshift Stone
-  standard: Lanayru Mine - Blow Right Digging Robot in Side Room near First Timeshift Stone
-  pretty: Lanayru Mine - Blow Right Digging Robot in Side Room near First Timeshift Stone
+- name: Lanayru Mine - Blow Right Digging Robot's Wall in Side Room near First Timeshift Stone
+  standard: Lanayru Mine - Blow Right Digging Robot's Wall in Side Room near First Timeshift Stone
+  pretty: Lanayru Mine - Blow Right Digging Robot's Wall in Side Room near First Timeshift Stone
   cryptic: <r<dusting a worker>> near a <y<large time distortion>>
 
 - name: Lanayru Mine - Chest in Side Room near First Timeshift Stone
@@ -3868,14 +3868,14 @@
   pretty: Lanayru Mine - Slingshot Right Robot Eye above First Minecart Doorway
   cryptic: <r<shooting the guardian>> of a <y<large time distortion>>
 
-- name: Lanayru Mine - Blow Left Digging Robot after First Minecart Ride
-  standard: Lanayru Mine - Blow Left Digging Robot after First Minecart Ride
-  pretty: Lanayru Mine - Blow Left Digging Robot after First Minecart Ride
+- name: Lanayru Mine - Blow Left Digging Robot's Wall after First Minecart Ride
+  standard: Lanayru Mine - Blow Left Digging Robot's Wall after First Minecart Ride
+  pretty: Lanayru Mine - Blow Left Digging Robot's Wall after First Minecart Ride
   cryptic: <r<dusting a worker>> before a <y<sandy tunnel>>
 
-- name: Lanayru Mine - Blow Right Digging Robot after First Minecart Ride
-  standard: Lanayru Mine - Blow Right Digging Robot after First Minecart Ride
-  pretty: Lanayru Mine - Blow Right Digging Robot after First Minecart Ride
+- name: Lanayru Mine - Blow Right Digging Robot's Wall after First Minecart Ride
+  standard: Lanayru Mine - Blow Right Digging Robot's Wall after First Minecart Ride
+  pretty: Lanayru Mine - Blow Right Digging Robot's Wall after First Minecart Ride
   cryptic: <r<dusting a worker>> before a <y<sandy tunnel>>
 
 - name: Lanayru Mine - Chest behind Northeast Statue
@@ -3893,14 +3893,14 @@
   pretty: Lanayru Mine - Rupee behind Southwest Statue
   cryptic: a <r<rupee hidden behind a falling statue>>
 
-- name: Lanayru Mine - Blow Digging Robot near Mine Exit
-  standard: Lanayru Mine - Blow Digging Robot near Mine Exit
-  pretty: Lanayru Mine - Blow Digging Robot near Mine Exit
+- name: Lanayru Mine - Blow Digging Robot's Wall near Mine Exit
+  standard: Lanayru Mine - Blow Digging Robot's Wall near Mine Exit
+  pretty: Lanayru Mine - Blow Digging Robot's Wall near Mine Exit
   cryptic: <r<dusting a worker>> near <y<rubble>>
 
-- name: Lanayru Mine - Blow Digging Robot near Last Mine Timeshift Stone
-  standard: Lanayru Mine - Blow Digging Robot near Last Mine Timeshift Stone
-  pretty: Lanayru Mine - Blow Digging Robot near Last Mine Timeshift Stone
+- name: Lanayru Mine - Blow Digging Robot's Wall near Last Mine Timeshift Stone
+  standard: Lanayru Mine - Blow Digging Robot's Wall near Last Mine Timeshift Stone
+  pretty: Lanayru Mine - Blow Digging Robot's Wall near Last Mine Timeshift Stone
   cryptic: <r<dusting a worker>> near a <y<small time distortion>>
 
 - name: Lanayru Mine - Chest at the End of Mine

--- a/data/world/Lanayru.yaml
+++ b/data/world/Lanayru.yaml
@@ -11,9 +11,9 @@
   locations:
     Lanayru Mine - Slingshot Left Eye of First Landing Robot: Slingshot
     Lanayru Mine - Slingshot Right Eye of First Landing Robot: Slingshot
-    Lanayru Mine - Blow Digging Robot before Side Room near First Timeshift Stone: Gust_Bellows
-    Lanayru Mine - Blow Left Digging Robot in Side Room near First Timeshift Stone: Gust_Bellows and 'Lanayru_Mine_First_Timeshift_Stone'
-    Lanayru Mine - Blow Right Digging Robot in Side Room near First Timeshift Stone: Gust_Bellows and 'Lanayru_Mine_First_Timeshift_Stone'
+    Lanayru Mine - Blow Digging Robot's Wall before Side Room near First Timeshift Stone: Gust_Bellows
+    Lanayru Mine - Blow Left Digging Robot's Wall in Side Room near First Timeshift Stone: Gust_Bellows and 'Lanayru_Mine_First_Timeshift_Stone'
+    Lanayru Mine - Blow Right Digging Robot's Wall in Side Room near First Timeshift Stone: Gust_Bellows and 'Lanayru_Mine_First_Timeshift_Stone'
     Lanayru Mine - Chest in Side Room near First Timeshift Stone: "'Lanayru_Mine_First_Timeshift_Stone'"
     Lanayru Mine - Rupee on Southeast Conveyor 1: Beetle
     Lanayru Mine - Rupee on Southeast Conveyor 2: Beetle
@@ -43,8 +43,8 @@
     Lanayru Mine Entry: "'Blow_Down_First_Mine_Statue'"
     Lanayru Mine End: Bomb_Bag or ('Blow_Down_First_Mine_Statue' and Hook_Beetle) or 'Obtain_Stamina_Potion' or logic_brakeslide
   locations:
-    Lanayru Mine - Blow Left Digging Robot after First Minecart Ride: Gust_Bellows
-    Lanayru Mine - Blow Right Digging Robot after First Minecart Ride: Gust_Bellows
+    Lanayru Mine - Blow Left Digging Robot's Wall after First Minecart Ride: Gust_Bellows
+    Lanayru Mine - Blow Right Digging Robot's Wall after First Minecart Ride: Gust_Bellows
     Lanayru Mine - Chest behind Northeast Statue: Bomb_Bag or ('Blow_Down_First_Mine_Statue' and Hook_Beetle)
     Lanayru Mine - Rupee behind Northeast Statue: Bomb_Bag or ('Blow_Down_First_Mine_Statue' and Hook_Beetle)
     Lanayru Mine - Rupee behind Southwest Statue: Bomb_Bag or ('Blow_Down_First_Mine_Statue' and Hook_Beetle)
@@ -63,8 +63,8 @@
     Lanayru Mine Statues Area: "'Blow_Down_First_Mine_Statue' or logic_brakeslide or 'Obtain_Stamina_Potion'"
     Lanayru Mine In Minecart: Can_Hit_Timeshift_Stone
   locations:
-    Lanayru Mine - Blow Digging Robot near Mine Exit: Gust_Bellows
-    Lanayru Mine - Blow Digging Robot near Last Mine Timeshift Stone: Gust_Bellows
+    Lanayru Mine - Blow Digging Robot's Wall near Mine Exit: Gust_Bellows
+    Lanayru Mine - Blow Digging Robot's Wall near Last Mine Timeshift Stone: Gust_Bellows
     Lanayru Mine - Chest at the End of Mine: Nothing # There's a baba in the way
     Lanayru Mine - Stamina Fruit after Falling Statues: Nothing
     Lanayru Mine - Stamina Fruit near Spumes 1: Nothing


### PR DESCRIPTION
## What does this address?
Because the names incorrectly say that you should blow the robots (and not the walls they are digging), these checks were reported to be bugged in #341.

These checks have been renamed from `Blow Digging Robot ...` to `Blow Digging Robot's Wall ...`

These new names aren't amazing and could do with reworking (cos they're very long now) but this should solve the immediate confusion