### PR TITLE
Add long range skyward strike trick

### DIFF
--- a/data/macros.yaml
+++ b/data/macros.yaml
@@ -93,7 +93,7 @@ Can Obtain a Shield: Pouch and can_access(Bazaar) # To buy a shield and dispose 
 
 Sword: Practice_Sword
 
-Long Range Skyward Strike: (Goddess_Sword and upgraded_skyward_strike) or True_Master_Sword
+Long Range Skyward Strike: logic_long_ranged_skyward_strikes and ((Goddess_Sword and upgraded_skyward_strike) or True_Master_Sword)
 
 Damaging Item: Sword or Bomb_Bag or Bow
 

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -1357,6 +1357,16 @@
     - "off": "You will only be expected to defeat Lizalfos enemies with a sword."
     - "on": "You may need to defeat Lizalfos enemies with only bombs or only the Bow."
 
+- name: logic_long_ranged_skyward_strikes
+  default_option: "off"
+  pretty_name: "Long Ranged Skyward Strikes"
+  pretty_options:
+    - "Off"
+    - "On"
+  options:
+    - "off": "You will not need to perform any Skyward Strikes that travel long distances."
+    - "on": "You may need to perform ranged Skyward Strikes to hit distant Goddess Cubes, enemies, or switches."
+
 - name: logic_gravestone_jump
   default_option: "off"
   pretty_name: Gravestone Jump

--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::TabShape::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>6</number>
       </property>
       <widget class="QWidget" name="getting_started_tab">
        <property name="sizePolicy">
@@ -2632,6 +2632,13 @@
                <widget class="RandoTriStateCheckBox" name="setting_logic_advanced_lizalfos_combat">
                 <property name="text">
                  <string>Advanced Lizalfos Combat</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="RandoTriStateCheckBox" name="setting_logic_long_ranged_skyward_strikes">
+                <property name="text">
+                 <string>Long Range Skyward Strikes</string>
                 </property>
                </widget>
               </item>

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -1743,6 +1743,11 @@ class Ui_main_window(object):
 
         self.verticalLayout_20.addWidget(self.setting_logic_advanced_lizalfos_combat)
 
+        self.setting_logic_long_ranged_skyward_strikes = RandoTriStateCheckBox(self.precise_items_group_box)
+        self.setting_logic_long_ranged_skyward_strikes.setObjectName(u"setting_logic_long_ranged_skyward_strikes")
+
+        self.verticalLayout_20.addWidget(self.setting_logic_long_ranged_skyward_strikes)
+
         self.setting_logic_skyview_precise_slingshot = RandoTriStateCheckBox(self.precise_items_group_box)
         self.setting_logic_skyview_precise_slingshot.setObjectName(u"setting_logic_skyview_precise_slingshot")
 
@@ -2774,7 +2779,7 @@ class Ui_main_window(object):
 
         self.retranslateUi(main_window)
 
-        self.tab_widget.setCurrentIndex(0)
+        self.tab_widget.setCurrentIndex(6)
 
 
         QMetaObject.connectSlotsByName(main_window)
@@ -2969,6 +2974,7 @@ class Ui_main_window(object):
         self.tricks_group_box.setTitle(QCoreApplication.translate("main_window", u"Tricks", None))
         self.precise_items_group_box.setTitle(QCoreApplication.translate("main_window", u"Precise Items", None))
         self.setting_logic_advanced_lizalfos_combat.setText(QCoreApplication.translate("main_window", u"Advanced Lizalfos Combat", None))
+        self.setting_logic_long_ranged_skyward_strikes.setText(QCoreApplication.translate("main_window", u"Long Range Skyward Strikes", None))
         self.setting_logic_skyview_precise_slingshot.setText(QCoreApplication.translate("main_window", u"Skyview Temple Precise Slingshot", None))
         self.setting_logic_lmf_ceiling_precise_slingshot.setText(QCoreApplication.translate("main_window", u"Lanayru Mining Facility Precise Slingshot", None))
         self.setting_logic_tot_slingshot.setText(QCoreApplication.translate("main_window", u"Temple of Time Precise Slingshot", None))


### PR DESCRIPTION
## What does this address?
After discussion in the discord server, it turns out that long range skyward strikes were always in logic. I've added a trick so that you cannot be expected to have to jumpslash skyward strike to activate distant goddess cubes


## How did/do you test these changes?
I was testing `Lanayru Desert - Goddess Cube near Caged Robot` in particular. I tested not having the trick on and I required clawshots to activate the cube. With the trick on, I only needed TMS or goddess sword + upgraded_skyward_strikes to be on