### PR TITLE
Update Eldin first ledge Rupee logic

### DIFF
--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -14,7 +14,6 @@
     Volcano East: Nothing
     Bokoblin Base Prison: Nothing
   locations:
-    Eldin Volcano - Rupee on Ledge before First Room: Beetle
     Eldin Volcano - Stamina Fruit in Rising Lava Room: Nothing
     Eldin Volcano - Chest behind Bombable Wall in First Room: Nothing
     Eldin Volcano - Rupee behind Bombable Wall in First Room: Nothing
@@ -39,6 +38,7 @@
     Mogma Turf Dive: Nothing
     Past Mogma Turf: Bomb_Bag or Hook_Beetle
   locations:
+    Eldin Volcano - Rupee on Ledge before First Room: Beetle
     Eldin Volcano - Chest after Blocked Crawlspace: Nothing
     Eldin Volcano - Southeast Rupee above Mogma Turf Entrance: Beetle
     Eldin Volcano - North Rupee above Mogma Turf Entrance: Beetle

--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -14,6 +14,7 @@
     Volcano East: Nothing
     Bokoblin Base Prison: Nothing
   locations:
+    Eldin Volcano - Rupee on Ledge before First Room: Beetle
     Eldin Volcano - Stamina Fruit in Rising Lava Room: Nothing
     Eldin Volcano - Chest behind Bombable Wall in First Room: Nothing
     Eldin Volcano - Rupee behind Bombable Wall in First Room: Nothing


### PR DESCRIPTION
## What does this address?

Modifies the logic to allow collecting the Rupee on First Ledge check with the Beetle from Volcano East

## How did/do you test these changes?

I checked with the tracker that this check is in logic with the Beetle and Ruby Tablet with the Eldin starting statue set to Volcano East. The WIP logic tooltips also agree.