### PR TITLE
Fix tracker hang when starting sword is random

### DIFF
--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -801,6 +801,7 @@ class Tracker:
         for inventory_button in self.ui.tracker_tab.findChildren(
             TrackerInventoryButton
         ):
+            assert isinstance(inventory_button, TrackerInventoryButton)
             inventory_button.world = self.world
             inventory_button.inventory = self.inventory
             inventory_button.state = 0
@@ -812,6 +813,11 @@ class Tracker:
                     inventory_button.add_forbidden_state(inventory_button.state)
                     inventory_button.state += 1
                     self.inventory[item] -= 1
+
+                    # Must have been set to random or something else is bugging out
+                    if inventory_button.state > len(inventory_button.items) - 1:
+                        inventory_button.state = 0
+                        inventory_button.forbidden_states = set()
 
             # Then update the buttons with any marked items from an autosave
             for item_name in autosave.get("marked_items", []):


### PR DESCRIPTION
## What does this address?
Fixes the issue Crystal found with the tracker.

Because the tracker doesn't evaluate random settings, having the starting sword value set to random causes 7 swords to be added to the starting inventory (it's based on the option index for the random option).

Idk why the tracker doesn't evaluate random settings but I can think of a few valid reasons so I didn't want to change that. I also didn't want to just add in yet another special case like the others:
* random_starting_tablet_count
* random_starting_item_count
* starting_hearts

This decision might not be the best tho. Instead, I added a check when setting up the inventory buttons. If the tracker is trying to start with too many of an item, act like the player isn't starting with any of that item. This should only happen if starting with a random amount of swords because the config makes sure you can't start with more than the max number of items


## How did/do you test these changes?
I launched a new tracker using Crystal's spoiler log as the config file (the setting string doesn't work because of the new trick setting that was added). Instead of showing TMS, there was no sword shown and clicking through the sword didn't cause the tracker to hang
