### PR TITLE
Activate dungeons by default on the tracker

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -154,7 +154,7 @@ class Main(QMainWindow):
             )
             default_description += (
                 OPTION_PREFIX
-                + 'Click a dungeon label (e.g. "SV") to set it as a required dungeon.'
+                + 'Click a dungeon label (e.g. "SV") to toggle if it is a required dungeon.'
             )
 
             self.ui.settings_current_option_description_label.setText(

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -886,7 +886,7 @@ class Tracker:
         for label in self.ui.tracker_tab.findChildren(TrackerDungeonLabel):
             label.world = self.world
             label.reset()
-            if label.abbreviation in autosave.get("active_dungeons", []):
+            if label.abbreviation not in autosave.get("not_active_dungeons", []):
                 label.on_clicked()
 
         self.update_tracker()
@@ -1495,10 +1495,10 @@ class Tracker:
         }
         autosave["random_settings"] = [s.name for s in self.random_settings]
         autosave["active_area"] = self.active_area.area
-        autosave["active_dungeons"] = [
+        autosave["not_active_dungeons"] = [
             dungeon.abbreviation
             for dungeon in self.ui.tracker_tab.findChildren(TrackerDungeonLabel)
-            if dungeon.active
+            if not dungeon.active
         ]
         autosave["allow_sphere_tracking"] = self.allow_sphere_tracking
         autosave["sphere_tracked_items"] = {


### PR DESCRIPTION
## What does this address?
Makes dungeons start active on the tracker and the user needs to deactivate unrequired dungeons


## How did/do you test these changes?
Started a new tracker and all the dungeons were active, the stats were correct, and dungeon locations showed up when you click into their region


## Notes
The changes aren't compatible with existing autosave data but that won't be an issue once we create the next release this will be a part of :p