### PR TITLE
Traps only replace junk

### DIFF
--- a/constants/itemconstants.py
+++ b/constants/itemconstants.py
@@ -112,24 +112,30 @@ ITEMS_NOT_TO_TRAP = (
 )
 
 # Item Pools
-ALL_JUNK_ITEMS: list[str] = [
-    MONSTER_HORN,
-    GOLDEN_SKULL,
-    GODDESS_PLUME,
-    DUSK_RELIC,
-    TUMBLEWEED,
-    FIVE_BOMBS,
-    GREEN_RUPEE,
-    BLUE_RUPEE,
-    RED_RUPEE,
-    SILVER_RUPEE,
-    GOLD_RUPEE,
-    UNCOMMON_TREASURE,
-    RARE_TREASURE,
-    EVIL_CRYSTAL,
-    ELDIN_ORE,
-    RUPOOR,
-]
+ALL_JUNK_ITEMS: list[str] = (
+    [
+        # HEART,
+        # SINGLE_ARROW,
+        TEN_ARROWS,
+        FIVE_BOMBS,
+        TEN_BOMBS,
+        # STAMINA_FRUIT,
+        # LIGHT_FRUIT,
+        FIVE_DEKU_SEEDS,
+        TEN_DEKU_SEEDS,
+        # FAIRY,
+        GREEN_RUPEE,
+        BLUE_RUPEE,
+        RED_RUPEE,
+        RUPOOR,
+    ]
+    + list(COMMON_TREASURES)
+    + list(UNCOMMON_TREASURES)
+    + list(RARE_TREASURES)
+    # + list(COMMON_BUGS)
+    # + list(UNCOMMON_BUGS)
+    # + list(RARE_BUGS)
+)
 
 MINIMAL_ITEM_POOL: list[str] = (
     [

--- a/logic/fill.py
+++ b/logic/fill.py
@@ -45,6 +45,17 @@ def fill_worlds(worlds: list[World]):
     # Remove major items from item pool
     item_pool = [item for item in item_pool if not item.is_major_item]
 
+    # Ensure that at least *some* traps get placed in progress locations if possible
+    traps = [item for item in item_pool if item.name in TRAP_SETTING_TO_ITEM.values()]
+
+    if len(traps) > 3:
+        traps = traps[:3]
+    fast_fill(traps.copy(), progress_locations)
+
+    # Remove placed traps from item pool
+    for trap in traps:
+        item_pool.remove(trap)
+
     # Place the rest of the items with fast fill
     fast_fill(item_pool, all_locations)
 

--- a/logic/spoiler_log.py
+++ b/logic/spoiler_log.py
@@ -166,7 +166,8 @@ def generate_spoiler_log(worlds: list[World]) -> None:
             if "Goddess Cube" not in location.types:
                 longest_name_length = max(longest_name_length, len(f"{location}"))
 
-        spoiler_log.write("\nAll Locations:\n")
+        # Output all enabled locations
+        spoiler_log.write("\nEnabled Locations:\n")
         for world in worlds:
             spoiler_log.write(f"    {world}:\n")
 
@@ -180,19 +181,12 @@ def generate_spoiler_log(worlds: list[World]) -> None:
                     and "Hint Location" not in location.types
                     and "Goddess Cube" not in location.types
                 ):
-                    override_item_name = None
-                    if (
-                        location.current_item.name in BOTTLE_ITEMS
-                        and location.current_item.name != EMPTY_BOTTLE
-                    ):
-                        override_item_name = EMPTY_BOTTLE
-
                     spoiler_log.write(
                         "        "
                         + spoiler_format_location(
                             location,
                             longest_name_length,
-                            override_item_name=override_item_name,
+                            override_item_name=get_item_override_name(location),
                         )
                         + "\n"
                     )
@@ -258,6 +252,33 @@ def generate_spoiler_log(worlds: list[World]) -> None:
                     spoiler_log.write("        Impa Hint:\n")
                     spoiler_log.write(f"            {world.impa_sot_hint}\n")
 
+        # Recalculate longest name length for all locations
+        longest_name_length = 0
+        for location in worlds[0].location_table.values():
+            if "Goddess Cube" not in location.types:
+                longest_name_length = max(longest_name_length, len(f"{location}"))
+
+        # Output all disabled locations
+        spoiler_log.write("\nDisabled Locations:\n")
+        for world in worlds:
+            spoiler_log.write(f"    {world}:\n")
+
+            disabled_shuffle_locations = get_disabled_shuffle_locations(
+                world.location_table, world.config
+            )
+
+            for location in world.location_table.values():
+                if location in disabled_shuffle_locations:
+                    spoiler_log.write(
+                        "        "
+                        + spoiler_format_location(
+                            location,
+                            longest_name_length,
+                            override_item_name=get_item_override_name(location),
+                        )
+                        + "\n"
+                    )
+
         log_settings(spoiler_log, config, worlds)
 
 
@@ -272,3 +293,12 @@ def generate_anti_spoiler_log(worlds: list[World]) -> None:
     with open(filepath, "w", encoding="utf-8") as anti_spoiler_log:
         log_basic_info(anti_spoiler_log, config, worlds)
         log_settings(anti_spoiler_log, config, worlds)
+
+
+def get_item_override_name(location: Location) -> str | None:
+    if (
+        location.current_item.name in BOTTLE_ITEMS
+        and location.current_item.name != EMPTY_BOTTLE
+    ):
+        return EMPTY_BOTTLE
+    return None

--- a/logic/world.py
+++ b/logic/world.py
@@ -656,20 +656,20 @@ class World:
             item_pool_copy.extend([item] * count)
 
         # Remove major items from item pool
-        major_item_pool = [item for item in item_pool_copy if item.is_major_item]
-        non_major_item_pool = [
-            item for item in item_pool_copy if not item.is_major_item
+        non_junk_pool = [
+            item for item in item_pool_copy if item.name not in ALL_JUNK_ITEMS
         ]
+        junk_pool = [item for item in item_pool_copy if item.name in ALL_JUNK_ITEMS]
 
         match self.setting("trap_mode"):
             case "trapish":
-                num_traps = len(non_major_item_pool) // 10
+                num_traps = len(junk_pool) // 10
             case "trapsome":
-                num_traps = len(non_major_item_pool) // 4
+                num_traps = len(junk_pool) // 4
             case "traps_o_plenty":
-                num_traps = len(non_major_item_pool) // 2
+                num_traps = len(junk_pool) // 2
             case "traptacular":
-                num_traps = len(non_major_item_pool)
+                num_traps = len(junk_pool)
             case _:
                 num_traps = 0
 
@@ -683,16 +683,16 @@ class World:
             return
 
         # Replace non-major items with traps
-        random.shuffle(non_major_item_pool)
+        random.shuffle(junk_pool)
 
         for replace_index in range(0, num_traps):
-            if replace_index >= len(non_major_item_pool):
+            if replace_index >= len(junk_pool):
                 break
 
             trap_item = TRAP_SETTING_TO_ITEM[random.choice(possible_traps)]
-            non_major_item_pool[replace_index] = self.get_item(trap_item)
+            junk_pool[replace_index] = self.get_item(trap_item)
 
-        new_item_pool = major_item_pool + non_major_item_pool
+        new_item_pool = non_junk_pool + junk_pool
 
         assert len(item_pool_copy) == len(new_item_pool)
 

--- a/tests/test_configs/traps_all.yaml
+++ b/tests/test_configs/traps_all.yaml
@@ -6,3 +6,4 @@ World 1:
   curse_traps: "on"
   noise_traps: "on"
   groose_traps: "on"
+  starting_inventory: []

--- a/tests/test_configs/traps_off.yaml
+++ b/tests/test_configs/traps_off.yaml
@@ -6,3 +6,4 @@ World 1:
   curse_traps: "on"
   noise_traps: "off"
   groose_traps: "off"
+  starting_inventory: []

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from constants.itemnames import *
 from logic.generate import generate
 from logic.config import *
 from logic.search import all_logic_satisfied
@@ -207,11 +208,13 @@ def test_default_multiworld_config() -> None:
 
 
 def test_traps_all() -> None:
-    config_test("traps_all.yaml")
+    worlds = config_test("traps_all.yaml")
+    _check_inventory_items_were_placed(worlds)
 
 
 def test_traps_off() -> None:
-    config_test("traps_off.yaml")
+    worlds = config_test("traps_off.yaml")
+    _check_inventory_items_were_placed(worlds)
 
 
 def test_beatable_only_config() -> None:
@@ -278,3 +281,38 @@ def test_good_starting_inventory() -> None:
         )
         == 2
     )
+
+
+def _check_inventory_items_were_placed(worlds: list[World]):
+    for world in worlds:
+        logicless_inventory_items: list[str] = (
+            [
+                HYLIAN_SHIELD,
+                CURSED_MEDAL,
+                TREASURE_MEDAL,
+                POTION_MEDAL,
+                BUG_MEDAL,
+                SV_MAP,
+                ET_MAP,
+                LMF_MAP,
+                AC_MAP,
+                SSH_MAP,
+                FS_MAP,
+                SK_MAP,
+            ]
+            + [HEART_MEDAL] * 2
+            + [RUPEE_MEDAL] * 2
+            + [HEART_PIECE] * 24
+            + [HEART_CONTAINER] * 6
+            + [LIFE_MEDAL] * 2
+        )
+
+        for location in world.location_table.values():
+            if (
+                location.current_item is not None
+                and location.current_item.name in logicless_inventory_items
+            ):
+                logicless_inventory_items.remove(location.current_item.name)
+
+        print(logicless_inventory_items)
+        assert len(logicless_inventory_items) == 0


### PR DESCRIPTION
## What does this address?
Makes traps only replace junk items instead of non_major_items. This means that players will always be able to complete their inventory ("100%ing the seed").


## How did/do you test these changes?
I generated seeds and made sure that all the heart containers and heart pieces were placed and not overwritten