### PR TITLE
Fix error when adding the disabled locations to the spoiler log

### DIFF
--- a/logic/spoiler_log.py
+++ b/logic/spoiler_log.py
@@ -264,7 +264,7 @@ def generate_spoiler_log(worlds: list[World]) -> None:
             spoiler_log.write(f"    {world}:\n")
 
             disabled_shuffle_locations = get_disabled_shuffle_locations(
-                world.location_table, world.config
+                world.location_table, world.config.settings[0]
             )
 
             for location in world.location_table.values():


### PR DESCRIPTION
## What does this address?
Fixes a bug that prevented seeds from being generated due to an incorrect argument being passed when getting the disabled locations to add to the spoiler log.


## How did/do you test these changes?
I was able to generate a seed with default settings without getting an error.