### PR TITLE
Update some upper Eldin stamina fruit logic

### DIFF
--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -108,8 +108,6 @@
     Eldin Volcano - Left Rupee behind Bombable Wall near Thrill Digger Cave: Nothing
     Eldin Volcano - Right Rupee behind Bombable Wall near Thrill Digger Cave: Nothing
     Eldin Volcano - Stamina Fruit above Slope after Volcano Ascent: Nothing
-    Eldin Volcano - Stamina Fruit next to Small Puddle: Nothing
-    Eldin Volcano - Stamina Fruit on Vine Wall near Thrill Digger: Nothing
 
 - name: Thrill Digger Cave
   hint_region: Eldin Volcano
@@ -146,6 +144,7 @@
     Earth Temple First Room: open_earth_temple or count(5, Key_Piece)
     Hot Cave: Nothing # You can use the bomb flower in one of the boko huts to blow up the tower
     Outside Upper Eldin Cave: "'Beaten_Boko_Base'"
+    Outside Thrill Digger Cave: can_access(Outside Thrill Digger Cave) or (logic_bomb_throws and Bomb_Bag)
   locations:
     Eldin Volcano - Blow Closest Torch West of Temple: Gust_Bellows
     Eldin Volcano - Blow Farthest Torch West of Temple: Gust_Bellows
@@ -163,6 +162,8 @@
     Eldin Volcano - Underground Rupee West of Temple 10: Mogma_Mitts
     Eldin Volcano - Digging Spot below Tower West of Temple: Digging_Mitts
     Eldin Volcano - Digging Spot behind Boulder on Slope before Temple: Digging_Mitts
+    Eldin Volcano - Stamina Fruit next to Small Puddle: Nothing
+    Eldin Volcano - Stamina Fruit on Vine Wall near Thrill Digger: Nothing
     Eldin Volcano - Stamina Fruit below Slope before Temple 1: Nothing
     Eldin Volcano - Stamina Fruit below Slope before Temple 2: Nothing
     Eldin Volcano - Stamina Fruit below Slope before Temple 3: Nothing


### PR DESCRIPTION
## What does this address?
Moves the stamina fruits near the puddle and on the vine wall to "Near Temple Entrance" in the logic files, so they require nothing if you have access to the top slope, since you can simply walk back down the cliff. An exit to the Outside Thrill Digger Cave area was also added, requiring the Precise Bomb Throw trick.


## How did/do you test these changes?
I verified with the tracker and its tooltips that
- Those two stamina fruits are accessible with nothing when starting at Temple Entrance
- Bomb Bag is sufficient to get the rupees near Thrill Digger cave when starting at Temple Entrance if the trick is enabled