### PR TITLE
More Tracker Touchups

### DIFF
--- a/data/tracker_areas.yaml
+++ b/data/tracker_areas.yaml
@@ -7,6 +7,11 @@
     - Lanayru
     - Sky
     - Inside the Thunderhead
+    - Everything Discovered
+
+- name: Everything Discovered
+  x: 10
+  y: 263
 
 - name: Sky
   alias: The Sky

--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -312,7 +312,6 @@
     Volcano Summit - Goddess Cube in Lava Lake: Fireshield_Earrings and (Long_Range_Skyward_Strike or ('Beaten_Boko_Base' and Goddess_Sword))
 
 - name: Volcano Summit Waterfall
-  hint_region: Volcano Summit
   events:
     Can Collect Water: Bottle
   exits:

--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -112,7 +112,6 @@
     Eldin Volcano - Stamina Fruit on Vine Wall near Thrill Digger: Nothing
 
 - name: Thrill Digger Cave
-  hint_region: Eldin Volcano
   events:
     Can Play Thrill Digger Minigame: Digging_Mitts
   exits:

--- a/data/world/Lanayru.yaml
+++ b/data/world/Lanayru.yaml
@@ -493,7 +493,7 @@
   exits:
     Shipyard Statue: Nothing
     Shipyard End of Minecart Ride: Nothing
-    Construction Bay Sand Pit: "'Defeat_Shipyard_Moldarach'"
+    Construction Bay Sand Pit: Nothing
     Lanayru Sand Sea: Nothing
   locations:
     Shipyard - Bonk Sign before Gortram the Rickety Coaster Operator: Nothing

--- a/gui/components/tracker_area.py
+++ b/gui/components/tracker_area.py
@@ -76,6 +76,15 @@ class TrackerArea(QLabel):
                 if loc not in locations_set:
                     all_locations.append(loc)
                     locations_set.add(loc)
+        # If this is the "Everything Discovered" area, then get everything which has been discovered
+        # in the world
+        if self.recent_search and self.area == "Everything Discovered":
+            connected_areas = self.recent_search.get_all_connected_areas()
+            for loc in self.recent_search.worlds[0].location_table.values():
+                if any(
+                    [la for la in loc.loc_access_list if la.area in connected_areas]
+                ):
+                    all_locations.append(loc)
         return all_locations
 
     def get_included_locations(
@@ -126,7 +135,7 @@ class TrackerArea(QLabel):
         if (
             len(self.locations) + len(self.tracker_children) == 0
             or self.recent_search is None
-        ):
+        ) and self.area != "Everything Discovered":
             return
 
         all_unmarked_locations = self.get_unmarked_locations(remove_special_types=False)

--- a/gui/components/tracker_entrance_label.py
+++ b/gui/components/tracker_entrance_label.py
@@ -15,12 +15,17 @@ class TrackerEntranceLabel(QLabel):
     disconnect_entrance = Signal(Entrance, str)
 
     def __init__(
-        self, entrance_: Entrance, parent_area_name_: str, recent_search_: Search
+        self,
+        entrance_: Entrance,
+        parent_area_name_: str,
+        recent_search_: Search,
+        show_full_connection_: bool,
     ) -> None:
         super().__init__()
         self.entrance = entrance_
         self.parent_area_name = parent_area_name_
         self.recent_search = recent_search_
+        self.show_full_connection = show_full_connection_
         self.setCursor(QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
         self.setMargin(10)
         self.setMinimumHeight(30)
@@ -34,7 +39,10 @@ class TrackerEntranceLabel(QLabel):
         connected_area = self.entrance.connected_area
         original_parent, original_connected = self.entrance.original_name.split(" -> ")
         first_part = (
-            f"{original_parent} to " if original_parent != self.parent_area_name else ""
+            f"{original_parent} to "
+            if self.entrance.parent_area.hard_assigned_region != self.parent_area_name
+            or self.show_full_connection
+            else ""
         )
         self.setText(
             f"{first_part}{original_connected} -> {connected_area.name if connected_area else '?'}"

--- a/gui/components/tracker_target_label.py
+++ b/gui/components/tracker_target_label.py
@@ -12,7 +12,11 @@ class TrackerTargetLabel(QLabel):
     clicked = Signal(Entrance, Entrance, str)
 
     def __init__(
-        self, entrance_: Entrance, target_: Entrance, parent_area_name_: str
+        self,
+        entrance_: Entrance,
+        target_: Entrance,
+        parent_area_name_: str,
+        show_full_connection: bool,
     ) -> None:
         super().__init__()
         self.entrance = entrance_
@@ -25,7 +29,12 @@ class TrackerTargetLabel(QLabel):
         self.setMaximumWidth(273)
         self.setWordWrap(True)
 
-        self.setText(self.target.replaces.original_name.split(" -> ")[1])
+        if show_full_connection:
+            self.setText(
+                f"{self.target.connected_area} from {self.target.replaces.parent_area}"
+            )
+        else:
+            self.setText(self.target.replaces.original_name.split(" -> ")[1])
 
     def mouseReleaseEvent(self, ev: QMouseEvent) -> None:
         if ev.button() == QtCore.Qt.MouseButton.LeftButton:

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -1514,8 +1514,10 @@ class Tracker:
 
         # Then read it again to input extra data
         autosave: dict = yaml_load(filename)
+        # Marked locations includes gossip stones, so read directly from
+        # the location table to include those
         autosave["marked_locations"] = [
-            loc.name for loc in self.world.get_all_item_locations() if loc.marked
+            loc.name for loc in self.world.location_table.values() if loc.marked
         ]
         autosave["marked_items"] = [item.name for item in self.inventory.elements()]
         autosave["connected_entrances"] = {

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -1168,7 +1168,9 @@ class Tracker:
 
         lead_to_label = QLabel(f"Where did {entrance.original_name} lead to?")
         lead_to_label.setMargin(10)
+        lead_to_label.setWordWrap(True)
         back_button = TrackerShowEntrancesButton(parent_area_name, "Back")
+        back_button.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
         back_button.show_area_entrances.connect(self.show_area_entrances)
 
         # Add a way to filter entrance targets

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -701,6 +701,10 @@ class Tracker:
         if starting_hearts == "random":
             starting_hearts.set_value("6")
 
+        # Set starting sword as No Sword if it's random
+        if self.world.setting("starting_sword") == "random":
+            self.world.setting("starting_sword").set_value("no_sword")
+
         # Build the world (only as necessary)
         self.world.build()
         self.world.perform_pre_entrance_shuffle_tasks()

--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -252,6 +252,11 @@ def create_entrance_pools(world: World) -> EntrancePools:
             ]
 
     if world.setting("randomize_overworld_entrances") == "on":
+        # Normally we allow any overworld entrances to link together.
+        # However, if overworld entrances are mixed with other entrance types
+        # that expect to only match with exclusively primary or non-primary
+        # entrances, we have to separate overworld entrances by their primary/
+        # non-primary distinction to fit with the other entrances
         exclude_overworld_reverse = (
             any("Overworld" in pool for pool in world.setting_map.mixed_entrance_pools)
             and world.setting("decouple_entrances") == "off"

--- a/logic/search.py
+++ b/logic/search.py
@@ -286,6 +286,25 @@ class Search:
             self.playthrough_spheres.pop(index)
             self.entrance_spheres.pop(index)
 
+    # Will return all areas which have a non-impossible connection
+    # from the root of the world graph
+    def get_all_connected_areas(self) -> set[Area]:
+        found_areas = set()
+        area_queue: list[Area] = [world.root for world in self.worlds]
+
+        while len(area_queue) > 0:
+            area = area_queue.pop(0)
+
+            for entrance in area.exits:
+                if entrance.requirement.type == RequirementType.IMPOSSIBLE:
+                    continue
+                if connected_area := entrance.connected_area:
+                    if connected_area not in found_areas:
+                        area_queue.append(connected_area)
+                        found_areas.add(connected_area)
+
+        return found_areas
+
     # Will dump a file which can be turned into a visual graph using graphviz
     # https://graphviz.org/download/
     # Use this command to generate the graph: dot -Tsvg <filename> -o world.svg

--- a/logic/world.py
+++ b/logic/world.py
@@ -210,10 +210,12 @@ class World:
                     if dungeon_name := area_node.get("dungeon", False):
                         self.add_dungeon(dungeon_name)
                         new_area.hint_regions.add(dungeon_name)
+                        new_area.hard_assigned_region = dungeon_name
                         if "dungeon_starting_area" in area_node:
                             self.get_dungeon(dungeon_name).starting_area = new_area
                     elif hint_region := area_node.get("hint_region", False):
                         new_area.hint_regions.add(hint_region)
+                        new_area.hard_assigned_region = hint_region
 
                     if "events" in area_node:
                         for event_name, req_str in area_node["events"].items():


### PR DESCRIPTION
## What does this address?
Reworks how the tracker decides which shuffled entrances are displayed for slightly more intuitive entrance tracking. Any entrances which can be found in a given area will be shown even if they're non-primary, but only if their reverse isn't found first when entrances are not decoupled. 

Also fixes some other minor issues:
- Logic for entering the shipyard construction bay from the dock no longer requires beating moldy 2
- Removes the forced Eldin Volcano hint region from the Thrill Digger Cave
- Removes the forced Volcano Summit region from the VS Waterfall area
- Fixes word wrapping on the `lead_to_label` when picking a target entrance
- Fixes the tracker thinking users always had TMS when starting with a random sword
- Properly autosaves marked gossip stones
- Adds an "Everything Discovered" area to the tracker for cases where the currently discovered area(s) are not part of any other area

## How did/do you test these changes?
I tested connecting every entrance in fully mixed coupled/decoupled entrance scenarios and didn't run into any issues.


