### PR TITLE
Rename some misleading Sealed Spiral checks

### DIFF
--- a/constants/configconstants.py
+++ b/constants/configconstants.py
@@ -152,6 +152,10 @@ LOCATION_ALIASES = {
     "Lanayru Mine - Blow Right Digging Robot after First Minecart Ride": "Lanayru Mine - Blow Right Digging Robot's Wall after First Minecart Ride",
     "Lanayru Mine - Blow Digging Robot near Mine Exit": "Lanayru Mine - Blow Digging Robot's Wall near Mine Exit",
     "Lanayru Mine - Blow Digging Robot near Last Mine Timeshift Stone": "Lanayru Mine - Blow Digging Robot's Wall near Last Mine Timeshift Stone",
+    # Since v1.1
+    "Sealed Grounds - Slingshot Mouth in Wall Drawing of Beast": "Sealed Grounds - Slingshot Open Mouth in Wall Drawing of Beast",
+    "Sealed Grounds - Bonk Wall Drawing of Hylia Raising Skyloft": "Sealed Grounds - Bonk Wall Drawing of Hylia Raising Sword and Harp",
+    "Sealed Grounds - Slingshot Sun in Wall Drawing of Worshippers": "Sealed Grounds - Slingshot Light of Ultimate Power in Wall Drawing of Worshippers",
 }
 
 SETTING_ALIASES = {

--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -1649,7 +1649,7 @@
   Paths:
     - stage/F401/r1/l0/TgReact/0xFC52
 
-- name: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Skyloft
+- name: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Sword and Harp
   original_item: Heart
   types:
     - Hidden Items
@@ -1657,7 +1657,7 @@
   Paths:
     - stage/F401/r1/l0/TgReact/0xFC53
 
-- name: Sealed Grounds - Slingshot Sun in Wall Drawing of Worshippers
+- name: Sealed Grounds - Slingshot Light of Ultimate Power in Wall Drawing of Worshippers
   original_item: Blue Rupee
   types:
     - Hidden Items
@@ -1665,7 +1665,7 @@
   Paths:
     - stage/F401/r1/l0/TgReact/0xFC55
 
-- name: Sealed Grounds - Slingshot Mouth in Wall Drawing of Beast
+- name: Sealed Grounds - Slingshot Open Mouth in Wall Drawing of Beast
   original_item: Blue Rupee
   types:
     - Hidden Items

--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -2296,19 +2296,19 @@
   pretty: Sealed Grounds - Bonk Wall between Pillars near Bird Statue
   cryptic: <r<disturbing the pillars>> of a <g<sealed bird>>
 
-- name: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Skyloft
-  standard: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Skyloft
-  pretty: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Skyloft
+- name: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Sword and Harp
+  standard: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Sword and Harp
+  pretty: Sealed Grounds - Bonk Wall Drawing of Hylia Raising Sword and Harp
   cryptic: <r<disturbing a mural Hylia>>
 
-- name: Sealed Grounds - Slingshot Sun in Wall Drawing of Worshippers
-  standard: Sealed Grounds - Slingshot Sun in Wall Drawing of Worshippers
-  pretty: Sealed Grounds - Slingshot Sun in Wall Drawing of Worshippers
-  cryptic: <r<shooting a painted sun>>
+- name: Sealed Grounds - Slingshot Light of Ultimate Power in Wall Drawing of Worshippers
+  standard: Sealed Grounds - Slingshot Light of Ultimate Power in Wall Drawing of Worshippers
+  pretty: Sealed Grounds - Slingshot Light of Ultimate Power in Wall Drawing of Worshippers
+  cryptic: <r<shooting a mural of ultimate power>>
 
-- name: Sealed Grounds - Slingshot Mouth in Wall Drawing of Beast
-  standard: Sealed Grounds - Slingshot Mouth in Wall Drawing of Beast
-  pretty: Sealed Grounds - Slingshot Mouth in Wall Drawing of Beast
+- name: Sealed Grounds - Slingshot Open Mouth in Wall Drawing of Beast
+  standard: Sealed Grounds - Slingshot Open Mouth in Wall Drawing of Beast
+  pretty: Sealed Grounds - Slingshot Open Mouth in Wall Drawing of Beast
   cryptic: <r<shooting a giant maw>>
 
 - name: Sealed Grounds - Bonk Rocks below Sealed Temple Entrance

--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -27,9 +27,9 @@
     Sealed Temple: Nothing
     Sealed Grounds: Nothing
   locations:
-    Sealed Grounds - Bonk Wall Drawing of Hylia Raising Skyloft: Nothing
-    Sealed Grounds - Slingshot Sun in Wall Drawing of Worshippers: Slingshot
-    Sealed Grounds - Slingshot Mouth in Wall Drawing of Beast: Slingshot
+    Sealed Grounds - Bonk Wall Drawing of Hylia Raising Sword and Harp: Nothing
+    Sealed Grounds - Slingshot Light of Ultimate Power in Wall Drawing of Worshippers: Slingshot
+    Sealed Grounds - Slingshot Open Mouth in Wall Drawing of Beast: Slingshot
     Sealed Grounds - Bonk Rocks below Sealed Temple Entrance: Nothing
     Sealed Grounds - Spiral Stamina Fruit 1: Nothing
     Sealed Grounds - Spiral Stamina Fruit 2: Nothing


### PR DESCRIPTION
## What does this address?
The Hidden Item checks at the bottom of the Sealed Grounds Spiral had misleading names. This fixes that :p


## How did/do you test these changes?
I successfully generated a seed with the checks enabled and disabled; and the tracker correctly showed the updated names