### PR TITLE
Try to explain the bazaar requirements in tracker tooltips

### DIFF
--- a/constants/configconstants.py
+++ b/constants/configconstants.py
@@ -158,6 +158,11 @@ LOCATION_ALIASES = {
     "Sealed Grounds - Slingshot Sun in Wall Drawing of Worshippers": "Sealed Grounds - Slingshot Light of Ultimate Power in Wall Drawing of Worshippers",
 }
 
+TRACKER_NOTE_EVENTS = {
+    "Access_Item_Check": "Access Item Check",
+    "Purchase_Shield": "Purchase Shield",
+}
+
 SETTING_ALIASES = {
     "shortcut_fs_lava_flow": "fs_lava_flow",
 }

--- a/data/macros.yaml
+++ b/data/macros.yaml
@@ -90,9 +90,9 @@ bottletypes: "Empty_Bottle or (not_tracker and filledbottletypes)"
 
 # Need access to the item check incase the user has a full pouch
 # or they picked up the cursed medal somewhere already
-Bottle: "can_access(Bazaar) and Pouch and bottletypes"
+Bottle: "'Access_Item_Check' and Pouch and bottletypes"
 
-Can Obtain a Shield: Pouch and can_access(Bazaar) # To buy a shield and dispose of Cursed Medal
+Can Obtain a Shield: Pouch and 'Purchase_Shield' and 'Access_Item_Check' # To buy a shield and dispose of Cursed Medal
 
 Sword: Practice_Sword
 

--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -253,6 +253,9 @@
   allowed_time_of_day: All
   events:
     Obtain Stamina Potion: Bottle and Raise_Lanayru_Mining_Facility
+    # important Tracker events
+    Access Item Check: Nothing
+    Purchase Shield: Nothing
   exits:
     Bazaar North: Nothing
     Bazaar West: Nothing

--- a/gui/components/tracker_location_label.py
+++ b/gui/components/tracker_location_label.py
@@ -275,6 +275,15 @@ class TrackerLocationLabel(QLabel):
                     else "red"
                 )
                 return f'<span style="color:{color}">{req.args[0]} Gratitude Crystals</span>'
+            case RequirementType.TRACKER_NOTE:
+                color = (
+                    "dodgerblue"
+                    if evaluate_requirement_at_time(
+                        req.args[1], self.recent_search, TOD.ALL, self.world
+                    )
+                    else "red"
+                )
+                return f'<span style="color:{color}">{req.args[2]}</span>'
             case RequirementType.OR:
                 # Recursively join requirements with "or"
                 # Only include parentheses if not at the top level (where they'd be redundant)
@@ -316,6 +325,8 @@ def sort_requirement(req: Requirement):
             return pretty_name(req.args[1].name, req.args[0])
         elif req.type == RequirementType.AND or req.type == RequirementType.OR:
             return by_item(req.args[0])
+        elif req.type == RequirementType.TRACKER_NOTE:
+            return req.args[2]
         return ""
 
     def sort_key(req: Requirement):

--- a/logic/requirements.py
+++ b/logic/requirements.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from .world import World
@@ -22,6 +22,7 @@ class RequirementType:
     NIGHT: int = 12
     WALLET_CAPACITY: int = 13
     GRATITUDE_CRYSTALS: int = 14
+    TRACKER_NOTE: int = 15
 
 
 class EvalSuccess:
@@ -393,6 +394,16 @@ def evaluate_requirement_at_time(
                 world.get_item("Gratitude Crystal Pack")
             ]
             return num_single_crystals + (num_crystal_packs * 5) >= expected_crystals
+
+        case RequirementType.TRACKER_NOTE:
+            return evaluate_requirement_at_time(req.args[1], search, time, world)
+
+
+def visit_requirement(req: Requirement, f: Callable[[Requirement], None]):
+    f(req)
+    if req.type == RequirementType.AND or req.type == RequirementType.OR:
+        for r in req.args:
+            visit_requirement(r, f)
 
 
 def evaluate_exit_requirement(search: "Search", exit_: "Entrance") -> int:

--- a/logic/tooltips/bits.py
+++ b/logic/tooltips/bits.py
@@ -161,6 +161,7 @@ class BitIndex:
         self.item_bits = {}
         self.wallet_cap = {}
         self.crystal_count = {}
+        self.notes = {}
         self.reverse_index: list[Requirement] = []
         self.counter = 0
 
@@ -207,6 +208,14 @@ class BitIndex:
                     return self.crystal_count[req_str]
                 else:
                     self.crystal_count[req_str] = self.counter
+                    self.reverse_index.append(req)
+                    return self.bump()
+            case RequirementType.TRACKER_NOTE:
+                req_str = f"{req.args[0]}"
+                if req_str in self.notes:
+                    return self.notes[req_str]
+                else:
+                    self.notes[req_str] = self.counter
                     self.reverse_index.append(req)
                     return self.bump()
             case _:


### PR DESCRIPTION
## What does this address?

Some checks require a bottle/shield, a pouch to hold them, and bazaar access (for the Item Check) to ensure you can actually pick those items up. This can unintuitively result in locations being "Impossible (please discover an entrance first)" in the tracker if you haven't found Bazaar access yet since the tooltips algorithm truthfully reports that there is no set of items that will put those locations in logic.

This changes the tooltips algorithm to fall back to treating the Item Check and Shield requirements specifically as opaque requirements when we know ahead of time that these requirements are unreachable. This hides the unreachability from the simplification algorithm and allows tooltips to display those requirements.

![grafik](https://github.com/mint-choc-chip-skyblade/sshd-rando/assets/14299449/257267f2-1969-4c6b-8100-5076ee74520a)

If you *do* have access to a special-cased requirement, the requirement will be shown *in addition* to any computed requirements (so e.g. if the Item Check is behind an entrance that requires Clawshots to get to, then the tooltip for a check that requires the Item Check will show "Clawshots and Access Item Check").

## How did/do you test these changes?

* This doesn't regress the existing automated tests
* Manual tooltip inspection with randomized entrances