### PR TITLE
A few more logic fixes

### DIFF
--- a/data/entrance_shuffle_data.yaml
+++ b/data/entrance_shuffle_data.yaml
@@ -110,7 +110,7 @@
         room: 0
         entrance: 0
   return:
-    connection: LMF First Room -> Top of LMF
+    connection: LMF First Room -> Lanayru Desert North
     # Conditional connections may only stay if the above connection
     # is vanilla
     conditional_vanilla_connections:

--- a/data/world/Lanayru Mining Facility.yaml
+++ b/data/world/Lanayru Mining Facility.yaml
@@ -4,7 +4,7 @@
   dungeon_starting_area: true
   exits:
     LMF First Hub: Hook_Beetle or (Whip and logic_lmf_whip_switch)
-    Top of LMF: Nothing
+    Lanayru Desert North: Nothing
   locations:
     Lanayru Mining Facility - Chest behind Bars: Nothing
     Lanayru Mining Facility - Left Front Rupee behind Statue: Nothing

--- a/data/world/Lanayru.yaml
+++ b/data/world/Lanayru.yaml
@@ -544,10 +544,6 @@
     Pirate Stronghold Dock: Clawshots or 'Finish_Pirate_Stronghold'
     Pirate Stronghold Top Door: Nothing
   locations:
-    # You *just* can't make it. If the Shark Head is lowered, it's easy but we can't check for it being lowered
-    Pirate Stronghold - Rupee on West Sea Pillar: Quick_Beetle
-    Pirate Stronghold - Rupee on East Sea Pillar: Quick_Beetle
-    Pirate Stronghold - Rupee on Bird Statue Pillar or Nose: Beetle # Still possible
     Pirate Stronghold - Goddess Cube on top of Shark Head: Clawshots and Goddess_Sword
 
 - name: Pirate Stronghold Interior

--- a/data/world/Sky.yaml
+++ b/data/world/Sky.yaml
@@ -86,9 +86,10 @@
     Lanayru Mine Entry Statue: Nothing
 
 - name: Bamboo Island
+  allowed_time_of_day: All
   hint_region: Sky
   exits:
-    Bamboo Island Interior: Day
+    Bamboo Island Interior: Nothing
     The Sky: Day
   locations:
     Bamboo Island - Slingshot Left Lantern: Slingshot
@@ -122,6 +123,7 @@
 
 
 - name: Beedle's Island
+  allowed_time_of_day: All
   hint_region: Sky
   exits:
     Beedle's Airshop: Night
@@ -143,6 +145,7 @@
 
 
 - name: Lumpy Pumpkin Exterior
+  allowed_time_of_day: All
   hint_region: Sky
   events:
     Start Kinas Quest: Day and 'Complete_Hot_Soup_Delivery'
@@ -166,37 +169,44 @@
 
 
 - name: Lumpy Pumpkin Back Door Exterior
+  allowed_time_of_day: All
   exits:
     Lumpy Pumpkin Exterior: Nothing
     Lumpy Pumpkin Back Door Interior: Nothing
 
 - name: Lumpy Pumpkin Main East Door Exterior
+  allowed_time_of_day: All
   exits:
     Lumpy Pumpkin Exterior: Nothing
     Lumpy Pumpkin Main East Door Interior: Nothing
 
 - name: Lumpy Pumpkin Main West Door Exterior
+  allowed_time_of_day: All
   exits:
     Lumpy Pumpkin Exterior: Nothing
     Lumpy Pumpkin Main West Door Interior: Nothing
 
 - name: Lumpy Pumpkin Back Door Interior
+  allowed_time_of_day: All
   exits:
     Lumpy Pumpkin Interior: Nothing
     Lumpy Pumpkin Back Door Exterior: Nothing
 
 - name: Lumpy Pumpkin Main East Door Interior
+  allowed_time_of_day: All
   exits:
     Lumpy Pumpkin Interior: Nothing
     Lumpy Pumpkin Main East Door Exterior: Nothing
 
 - name: Lumpy Pumpkin Main West Door Interior
+  allowed_time_of_day: All
   exits:
     Lumpy Pumpkin Interior: Nothing
     Lumpy Pumpkin Main West Door Exterior: Nothing
 
 
 - name: Lumpy Pumpkin Interior
+  allowed_time_of_day: All
   can_sleep: true
   events:
     Start Hot Soup Delivery: Bottle

--- a/logic/area.py
+++ b/logic/area.py
@@ -210,7 +210,7 @@ def assign_hint_regions_and_dungeon_locations(starting_area: Area):
         area = area_queue.pop(0)
         already_checked.add(area)
 
-        if len(area.hint_regions) > 0 or area.name == "Root":
+        if area.hard_assigned_region or area.name == "Root":
             for region in area.hint_regions:
                 # Don't add None if we come across it
                 if region != "None":

--- a/logic/entrance.py
+++ b/logic/entrance.py
@@ -106,7 +106,8 @@ class Entrance:
         previously_connected = self.connected_area
         self.connected_area = None
         for entrance in self.conditional_vanilla_connections:
-            entrance.disconnect()
+            if entrance.connected_area:
+                entrance.disconnect()
         return previously_connected
 
     def bind_two_way(self, return_entrance: "Entrance") -> None:

--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -635,7 +635,9 @@ def shuffle_entrance_pool(
             )
             logging.getLogger("").debug(f"\t{error}")
 
-    raise EntranceShuffleError("Ran out of retries when shuffling entrances")
+    raise EntranceShuffleError(
+        "Ran out of retries when shuffling entrances. If you see this error, try using a few different seeds to see if any generate successfully"
+    )
 
 
 def shuffle_entrances(

--- a/logic/requirements.py
+++ b/logic/requirements.py
@@ -37,6 +37,17 @@ class TOD:
     NIGHT: int = 0b10
     ALL: int = 0b11
 
+    def from_str(str) -> int:
+        match str:
+            case "Day Only":
+                return TOD.DAY
+            case "Night Only":
+                return TOD.NIGHT
+            case "All":
+                return TOD.ALL
+            case _:
+                raise RuntimeError(f"Unknown time of day specifier {str}")
+
 
 ALL_TODS = [TOD.DAY, TOD.NIGHT]
 
@@ -430,7 +441,7 @@ def evaluate_exit_requirement(search: "Search", exit_: "Entrance") -> int:
         return EvalSuccess.NONE
 
     for time in ALL_TODS:
-        if potential_time_spread & time:
+        if potential_time_spread & time & parent_area.allowed_tod:
             eval_test = evaluate_requirement_at_time(
                 exit_.requirement, search, time, exit_.world
             )

--- a/logic/world.py
+++ b/logic/world.py
@@ -195,15 +195,11 @@ class World:
                     new_area.world = self
                     defined_areas.add(new_area)
 
-                    if (
-                        "allowed_time_of_day" in area_node
-                        and self.setting("natural_night_connections") == "on"
-                    ):
-                        new_area.allowed_tod = (
-                            TOD.DAY
-                            if area_node["allowed_time_of_day"] == "Day Only"
-                            else TOD.ALL
-                        )
+                    # If natural night connections are enforced, any area which
+                    # doesn't have an All specification is considered to only
+                    # be accessible during the Day
+                    if self.setting("natural_night_connections") == "on":
+                        new_area.allowed_tod = TOD.from_str(area_node.get("allowed_time_of_day", "Day Only"))
 
                     new_area.can_sleep = area_node.get("can_sleep", False)
 

--- a/logic/world.py
+++ b/logic/world.py
@@ -199,7 +199,9 @@ class World:
                     # doesn't have an All specification is considered to only
                     # be accessible during the Day
                     if self.setting("natural_night_connections") == "on":
-                        new_area.allowed_tod = TOD.from_str(area_node.get("allowed_time_of_day", "Day Only"))
+                        new_area.allowed_tod = TOD.from_str(
+                            area_node.get("allowed_time_of_day", "Day Only")
+                        )
 
                     new_area.can_sleep = area_node.get("can_sleep", False)
 


### PR DESCRIPTION
## What does this address?

- Fixes hint regions not getting properly cleared for some areas. This was causing locations to appear at incorrect areas in the tracker.
- Change exiting LMF to connect to Lanayru Desert North instead of Top of LMF. Otherwise this puts the checks on the raised LMF structure in logic before it's raised.
- Remove the freestanding rupee locations from the `Pirate Stronghold Inside the Shark Head` area.
- Properly enforce natural night time connections. Turns out they weren't being checked properly, oops. (Thanks @robojumper for pointing this out).
- Fix accidentally disconnecting conditional exits multiple times.

## How did/do you test these changes?

I used the tracker to test the various above logic scenarios and all behaved as we would expect.

## Notes
Since natural night connections are *actually* being enforced now, there is a higher chance of entrance randomization failure, but it should still overall be very low. One of the error messages has been changed to tell users to try generating with a few different seeds if the entrance shuffling algorithm ever "runs out of retries" when placing entrances due to trying to enforcing natural night time connections. The proper fix for this would probably be to put some priority system in place for which entrances should be placed first, but even that wouldn't necessarily guarantee more notable success with entrance placements.

Another weird thing is that since the tooltips don't show any day/night requirements, it's possible for some locations to show up as red on the tracker because they are inaccessible, but have the tooltip show up as completely blue because all the item requirements are there, just not the day/night requirement.
