### PR TITLE
Ensure empty mixed pools also get saved to config/presets

### DIFF
--- a/logic/config.py
+++ b/logic/config.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import yaml
 from constants.configconstants import (
     CONFIG_FIELDS,
+    ENTRANCE_TYPES,
     PREFERENCE_FIELDS,
     SETTING_ALIASES,
     get_default_setting,
@@ -166,10 +167,12 @@ def write_config_to_file(filename: Path, config: Config):
                 config_out[world_num]["excluded_hint_locations"].append(loc)
 
             # Map mixed pools
-            config_out[world_num]["mixed_entrance_pools"] = []
+            config_out[world_num]["mixed_entrance_pools"] = [
+                list() for _ in range(len(ENTRANCE_TYPES) - 1)
+            ]
 
-            for pool in setting_map.mixed_entrance_pools:
-                config_out[world_num]["mixed_entrance_pools"].append(pool)
+            for pool_index, pool in enumerate(setting_map.mixed_entrance_pools):
+                config_out[world_num]["mixed_entrance_pools"][pool_index] = pool
 
         yaml.safe_dump(config_out, config_file, sort_keys=False)
 


### PR DESCRIPTION
## What does this address?
Fixes the issue where loading a preset with mixed pools will only overwrite the non-empty pools.

E.g. if you have a preset where:
`mixed_entrance_pools: [[Dungeon, Door]]`

And you load that preset over existing settings where:
`mixed_entrance_pools: [[Door], [Overworld], [Trial Gate]]`

You would get this:
`mixed_entrance_pools: [[Dungeon, Door], [Overworld], [Trial Gate]]`

instead of:
`mixed_entrance_pools: [[Dungeon, Door]]`


## How did/do you test these changes?
* Add something to mixed pool 1
* Save that as a preset
* Add something to mixed pool 2
* Load the saved preset
* Mixed pool 2 should be empty (and was when I tested it)