### PR TITLE
Sky Keep dungeon setting

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -1074,6 +1074,25 @@
       param2: 3 # item
       next: -1
       param3: 9
+  - name: Add flow for Sky Keep goal location sign
+    type: entryadd
+    entry:
+      name: "107_99"
+      value: Sky Keep goal location sign start
+  - name: Sky Keep goal location sign start
+    type: flowadd
+    flow:
+      type: start
+      next: Show Sky Keep goal location sign text 
+  - name: Sky Keep goal location sign text with replaced text
+    type: textadd
+  - name: Show Sky Keep goal location sign text
+    type: flowadd
+    flow:
+      type: type1
+      next: -1
+      param3: 88
+      param4: Sky Keep goal location sign text with replaced text
 
 108-ShinkanA:
   - name: Owlans Shield

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -4771,6 +4771,19 @@ D003_7: # Sky Keep Entrance Room
     layer: 0
     room: 0
     objtype: OBJ
+  - name: Add stone statue to tell goal location
+    type: objadd
+    layer: 0
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xFFFF2A2F # entrypoint 107_99
+      params2: 0xFFFFFFFF
+      posx: 650
+      posy: 0
+      posz: 2070
+      angley: 0xC000
+      name: KanbanS
   - name: Remove bars opening cs
     type: objpatch
     id: 0xFC16

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -525,9 +525,19 @@
   default_option: 2
   pretty_name: Required Dungeons
   pretty_options:
-    - 0-6
+    - 0-7
   options:
-    - 0-6: "Choose how many dungeons will have required items on their dungeon completion checks. Triforces, then swords, then other progress items are chosen, in this order."
+    - 0-7: "Choose how many dungeons will have required items on their dungeon completion checks. Triforces, then swords, then other progress items are chosen, in this order."
+
+- name: dungeons_include_sky_keep
+  default_option: "off"
+  pretty_name: Include Sky Keep as a Dungeon
+  pretty_options:
+    - "Off"
+    - "On"
+  options:
+    - "off": "Only the 6 main dungeons may be selected as required dungeons."
+    - "on": "Sky Keep may be selected as a required dungeon needed to beat the seed. If selected, one of the \"Sacred Power\" locations will be chosen as the \"Goal Location\" containing an important item (shown on a stone tablet in the 1st room of Sky Keep)."
 
 - name: empty_unrequired_dungeons
   tracker_important: true

--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -5547,16 +5547,19 @@
   standard: Sky Keep - Sacred Power of Din
   pretty: Sky Keep - Sacred Power of Din
   cryptic: the <r<power of a goddess>>
+  goal_name: a Sacred Power
 
 - name: Sky Keep - Sacred Power of Nayru
   standard: Sky Keep - Sacred Power of Nayru
   pretty: Sky Keep - Sacred Power of Nayru
   cryptic: the <r<wisdom of a goddess>>
+  goal_name: a Sacred Power
 
 - name: Sky Keep - Sacred Power of Farore
   standard: Sky Keep - Sacred Power of Farore
   pretty: Sky Keep - Sacred Power of Farore
   cryptic: the <r<courage of a goddess>>
+  goal_name: a Sacred Power
 
 - name: The Goddess's Silent Realm - Stamina Fruit on Knight Academy Ledge
   standard: The Goddess's Silent Realm - Stamina Fruit on Knight Academy Ledge
@@ -5869,6 +5872,18 @@
 
 - name: FFW Bucha stay text
   standard: "Talk to me again if you change your\nmind, kewwwwww.<action0 \x0c>"
+
+- name: Sky Keep No Goal Location Text
+  standard: "Hero of the Goddess!\nSeek now the exit."
+
+- name: Sky Keep Goal Location Sacred Power of Farore Text
+  standard: "Hero of the Goddess!\nSeek now the <g<Sacred Power of Farore>>."
+
+- name: Sky Keep Goal Location Sacred Power of Nayru Text
+  standard: "Hero of the Goddess!\nSeek now the <b<Sacred Power of Nayru>>."
+
+- name: Sky Keep Goal Location Sacred Power of Din Text
+  standard: "Hero of the Goddess!\nSeek now the <r<Sacred Power of Din>>."
 
 # Fi text
 - name: No Fi Hints Text

--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -5905,13 +5905,13 @@
   standard: "Welcome to your new adventure, Master. I have\n<r<important information>> about your journey."
 
 - name: No Required Dungeons Text
-  standard: "I detect no dungeons with strong readings."
+  standard: "I detect <r<no dungeons>> with strong readings."
 
 - name: Some Required Dungeons Text
   standard: "I detect strong readings in the following dungeons:\n{dungeon_text}"
 
 - name: All Required Dungeons Text
-  standard: "I detect many strong readings. I recommend you\ncomplete all the dungeons."
+  standard: "I detect many strong readings. I recommend you\n<r<complete all the dungeons>>."
 
 - name: Fi Information Text Patch
   standard: "Yes, Master. What information do you seek?\n[1]Hints[2]Notes[3]Required Dungeons[4-]Never mind."

--- a/data/world/Sky Keep.yaml
+++ b/data/world/Sky Keep.yaml
@@ -103,7 +103,6 @@
 
 
 - name: SK Sacred Power of Farore Room
-  dungeon: Sky Keep
   exits:
     SK Ancient Cistern Room South: Nothing
   locations:
@@ -127,7 +126,6 @@
     
 
 - name: SK Sacred Power of Din Room
-  dungeon: Sky Keep
   exits:
     SK Fire Sanctuary Room End Platform: Nothing
   locations:
@@ -147,7 +145,6 @@
 
 
 - name: SK Sacred Power of Nayru Room
-  dungeon: Sky Keep
   exits:
     SK Sandship Room West: Nothing
   locations:

--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::TabShape::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>9</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="getting_started_tab">
        <property name="sizePolicy">
@@ -892,6 +892,13 @@
               </widget>
              </item>
             </layout>
+           </item>
+           <item>
+            <widget class="RandoTriStateCheckBox" name="setting_dungeons_include_sky_keep">
+             <property name="text">
+              <string>Include Sky Keep as a Dungeon</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="RandoTriStateCheckBox" name="setting_empty_unrequired_dungeons">
@@ -3970,8 +3977,8 @@ QPushButton {
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>546</width>
-               <height>340</height>
+               <width>100</width>
+               <height>30</height>
               </rect>
              </property>
              <property name="maximumSize">

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'main.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.1
+## Created by: Qt User Interface Compiler version 6.6.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -609,6 +609,11 @@ class Ui_main_window(object):
 
         self.verticalLayout_13.addLayout(self.required_dungeons_layout)
 
+        self.setting_dungeons_include_sky_keep = RandoTriStateCheckBox(self.beat_the_game_group_box)
+        self.setting_dungeons_include_sky_keep.setObjectName(u"setting_dungeons_include_sky_keep")
+
+        self.verticalLayout_13.addWidget(self.setting_dungeons_include_sky_keep)
+
         self.setting_empty_unrequired_dungeons = RandoTriStateCheckBox(self.beat_the_game_group_box)
         self.setting_empty_unrequired_dungeons.setObjectName(u"setting_empty_unrequired_dungeons")
 
@@ -825,8 +830,8 @@ class Ui_main_window(object):
 
         self.line = QFrame(self.open_dungeons_group_box)
         self.line.setObjectName(u"line")
-        self.line.setFrameShape(QFrame.Shape.HLine)
-        self.line.setFrameShadow(QFrame.Shadow.Sunken)
+        self.line.setFrameShape(QFrame.HLine)
+        self.line.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_25.addWidget(self.line)
 
@@ -1034,8 +1039,8 @@ class Ui_main_window(object):
 
         self.mixed_entrance_pools_hline = QFrame(self.mixed_entrance_pools_group_box)
         self.mixed_entrance_pools_hline.setObjectName(u"mixed_entrance_pools_hline")
-        self.mixed_entrance_pools_hline.setFrameShape(QFrame.Shape.HLine)
-        self.mixed_entrance_pools_hline.setFrameShadow(QFrame.Shadow.Sunken)
+        self.mixed_entrance_pools_hline.setFrameShape(QFrame.HLine)
+        self.mixed_entrance_pools_hline.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_28.addWidget(self.mixed_entrance_pools_hline)
 
@@ -2073,8 +2078,8 @@ class Ui_main_window(object):
 
         self.player_cosmetics_hline = QFrame(self.player_cosmetics_group_box)
         self.player_cosmetics_hline.setObjectName(u"player_cosmetics_hline")
-        self.player_cosmetics_hline.setFrameShape(QFrame.Shape.HLine)
-        self.player_cosmetics_hline.setFrameShadow(QFrame.Shadow.Sunken)
+        self.player_cosmetics_hline.setFrameShape(QFrame.HLine)
+        self.player_cosmetics_hline.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_37.addWidget(self.player_cosmetics_hline)
 
@@ -2165,8 +2170,8 @@ class Ui_main_window(object):
 
         self.utils_hline = QFrame(self.file_setup_group_box)
         self.utils_hline.setObjectName(u"utils_hline")
-        self.utils_hline.setFrameShape(QFrame.Shape.HLine)
-        self.utils_hline.setFrameShadow(QFrame.Shadow.Sunken)
+        self.utils_hline.setFrameShape(QFrame.HLine)
+        self.utils_hline.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_31.addWidget(self.utils_hline)
 
@@ -2192,8 +2197,8 @@ class Ui_main_window(object):
 
         self.utils_hline_2 = QFrame(self.file_setup_group_box)
         self.utils_hline_2.setObjectName(u"utils_hline_2")
-        self.utils_hline_2.setFrameShape(QFrame.Shape.HLine)
-        self.utils_hline_2.setFrameShadow(QFrame.Shadow.Sunken)
+        self.utils_hline_2.setFrameShape(QFrame.HLine)
+        self.utils_hline_2.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_31.addWidget(self.utils_hline_2)
 
@@ -2227,8 +2232,8 @@ class Ui_main_window(object):
 
         self.utils_hline_3 = QFrame(self.file_setup_group_box)
         self.utils_hline_3.setObjectName(u"utils_hline_3")
-        self.utils_hline_3.setFrameShape(QFrame.Shape.HLine)
-        self.utils_hline_3.setFrameShadow(QFrame.Shadow.Sunken)
+        self.utils_hline_3.setFrameShape(QFrame.HLine)
+        self.utils_hline_3.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_31.addWidget(self.utils_hline_3)
 
@@ -2658,7 +2663,7 @@ class Ui_main_window(object):
         self.tracker_locations_scroll_area.setWidgetResizable(True)
         self.tracker_locations_scroll_widget = QWidget()
         self.tracker_locations_scroll_widget.setObjectName(u"tracker_locations_scroll_widget")
-        self.tracker_locations_scroll_widget.setGeometry(QRect(0, 0, 546, 340))
+        self.tracker_locations_scroll_widget.setGeometry(QRect(0, 0, 100, 30))
         self.tracker_locations_scroll_widget.setMaximumSize(QSize(546, 16777215))
         self.tracker_locations_scroll_layout = QHBoxLayout(self.tracker_locations_scroll_widget)
         self.tracker_locations_scroll_layout.setSpacing(0)
@@ -2801,7 +2806,7 @@ class Ui_main_window(object):
 
         self.retranslateUi(main_window)
 
-        self.tab_widget.setCurrentIndex(9)
+        self.tab_widget.setCurrentIndex(1)
 
 
         QMetaObject.connectSlotsByName(main_window)
@@ -2860,6 +2865,7 @@ class Ui_main_window(object):
         self.beat_the_game_group_box.setTitle(QCoreApplication.translate("main_window", u"Beat the Game", None))
         self.got_sword_requirement_label.setText(QCoreApplication.translate("main_window", u"Gate of Time Sword Requirement", None))
         self.required_dungeons_label.setText(QCoreApplication.translate("main_window", u"Required Dungeons", None))
+        self.setting_dungeons_include_sky_keep.setText(QCoreApplication.translate("main_window", u"Include Sky Keep as a Dungeon", None))
         self.setting_empty_unrequired_dungeons.setText(QCoreApplication.translate("main_window", u"Barren Unrequired Dungeons", None))
         self.setting_skip_horde.setText(QCoreApplication.translate("main_window", u"Skip The Horde Fight", None))
         self.setting_skip_g3.setText(QCoreApplication.translate("main_window", u"Skip Ghirahim 3 Fight", None))

--- a/logic/dungeon.py
+++ b/logic/dungeon.py
@@ -27,6 +27,13 @@ class Dungeon:
         return self.name
 
     def should_be_barren(self) -> bool:
+        # If Sky Keep is explicitly disabled it should always be barren regardless of other settings.
+        if (
+            self.name == "Sky Keep"
+            and self.world.setting("dungeons_include_sky_keep") == "off"
+        ):
+            return True
+
         return (
             not self.required
             and self.world.setting("empty_unrequired_dungeons") == "on"

--- a/logic/search.py
+++ b/logic/search.py
@@ -407,7 +407,11 @@ def all_logic_satisfied(worlds: list["World"], item_pool: Counter[Item] = {}) ->
             accessible_goal_locations = [
                 l
                 for l in world.location_table.values()
-                if l.is_goal_location and not l.name.startswith("Sky Keep")
+                if l.is_goal_location
+                and (
+                    world.setting("dungeons_include_sky_keep") == "on"
+                    or not l.name.startswith("Sky Keep")
+                )
             ]
             if (
                 world.get_game_winning_item() not in search.owned_items

--- a/logic/world.py
+++ b/logic/world.py
@@ -304,9 +304,13 @@ class World:
                 setting.resolve_if_random()
 
     def resolve_conflicting_settings(self) -> None:
-        # Resolve any conflicting settings here if we ever
-        # find any
-        pass
+        if (
+            self.setting("required_dungeons") == "7"
+            and self.setting("dungeons_include_sky_keep") == "off"
+        ):
+            raise ValueError(
+                "Cannot require 7 dungeons when Sky Keep is not a dungeon. Please either reduce the required dungeon count or enable Sky Keep to be a required dungeon."
+            )
 
     def place_hardcoded_items(self) -> None:
         defeat_demise = self.get_location("Hylia's Realm - Defeat Demise")
@@ -413,18 +417,17 @@ class World:
         num_required_dungeons = self.setting("required_dungeons").value_as_number()
         num_chosen_dungeons = 0
 
-        dungeons = [
-            d
-            for d in self.dungeons.values()
-            if d.goal_location and d.name != "Sky Keep"
-        ]
+        dungeons = [d for d in self.dungeons.values() if d.goal_location]
 
         # Disable the Eldin Pillar -> Fire Sanctuary entrance so that
         # it doesn't erroneously give "access" to fire sanctuary in no logic
         self.get_entrance("Eldin Pillar -> Inside the Fire Sanctuary Statue").disable()
+
         # Also disable Sky Keep's entrance if it's not required
-        sky_keep = self.get_dungeon("Sky Keep")
-        sky_keep.starting_entrance.disabled = sky_keep.should_be_barren()
+        if self.setting("dungeons_include_sky_keep") == "off":
+            sky_keep = self.get_dungeon("Sky Keep")
+            sky_keep.starting_entrance.disabled = True
+            dungeons.remove(sky_keep)
 
         random.shuffle(dungeons)
         item_pool = get_complete_item_pool(self.worlds)
@@ -575,10 +578,6 @@ class World:
             self.location_table, self.setting_map
         ):
             location.progression = False
-
-        # Sky Keep will never be a required dungeon with empty unrequired dungeons
-        if self.setting("empty_unrequired_dungeons") == "on":
-            self.dungeons["Sky Keep"].required = False
 
         # Set beedle's shop items as nonprogress if they can only contain junk
         if self.setting("beedle_shop_shuffle") == "junk_only":

--- a/patches/dynamictextpatches.py
+++ b/patches/dynamictextpatches.py
@@ -14,6 +14,9 @@ def add_dynamic_text_patches(
         add_impa_text_patches(world, event_patch_handler)
 
     add_song_text_patches(world, event_patch_handler)
+
+    add_sky_keep_goal_loc_patches(world)
+
     add_rando_hash(world, event_patch_handler)
 
 
@@ -373,6 +376,26 @@ def add_song_text_patches(world: World, event_patch_handler: EventPatchHandler) 
                 "index": inventory_text_idx,
             },
         )
+
+
+def add_sky_keep_goal_loc_patches(world: World) -> None:
+    sky_keep = world.get_dungeon("Sky Keep")
+    goal = sky_keep.goal_location
+    goal_text = get_text_data("Sky Keep No Goal Location Text")
+
+    if sky_keep.required and goal is not None:
+        if goal.name.endswith("Farore"):
+            goal_text = get_text_data(
+                "Sky Keep Goal Location Sacred Power of Farore Text"
+            )
+        elif goal.name.endswith("Nayru"):
+            goal_text = get_text_data(
+                "Sky Keep Goal Location Sacred Power of Nayru Text"
+            )
+        elif goal.name.endswith("Din"):
+            goal_text = get_text_data("Sky Keep Goal Location Sacred Power of Din Text")
+
+    add_text_data("Sky Keep goal location sign text with replaced text", goal_text)
 
 
 def add_rando_hash(world: World, event_patch_handler: EventPatchHandler) -> None:

--- a/patches/dynamictextpatches.py
+++ b/patches/dynamictextpatches.py
@@ -42,17 +42,19 @@ def add_fi_text_patches(world: World, event_patch_handler: EventPatchHandler) ->
     for text in colorful_dungeon_text:
         dungeon_text += text + Text("\n")
 
-    match len(colorful_dungeon_text):
-        case 0:
-            required_dungeons_text = get_text_data("No Required Dungeons Text")
-        case 6:
-            required_dungeons_text = get_text_data("All Required Dungeons Text")
-        case _:
-            required_dungeons_text = get_text_data("Some Required Dungeons Text")
-            required_dungeons_text = required_dungeons_text.replace(
-                "{dungeon_text}",
-                dungeon_text,
-            )
+    num_dungeons = len(colorful_dungeon_text)
+    if num_dungeons == 0:
+        required_dungeons_text = get_text_data("No Required Dungeons Text")
+    elif num_dungeons == 7 or (
+        num_dungeons == 6 and world.setting("dungeons_include_sky_keep") == "off"
+    ):
+        required_dungeons_text = get_text_data("All Required Dungeons Text")
+    else:
+        required_dungeons_text = get_text_data("Some Required Dungeons Text")
+        required_dungeons_text = required_dungeons_text.replace(
+            "{dungeon_text}",
+            dungeon_text,
+        )
 
     event_patch_handler.append_to_event_patches(
         "006-8KenseiNormal",

--- a/tests/test_configs/max_entrance_rando.yaml
+++ b/tests/test_configs/max_entrance_rando.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: TESTTESTTESTTEST
 World 1:
   random_starting_spawn: anywhere
   randomize_dungeon_entrances: "on"


### PR DESCRIPTION
## What does this address?
Adds a setting to include Sky Keep as a potentially required dungeon. To account for this, the required dungeons setting now ranges from 0 -> 7.

When enabled, Sky Keep has a chance of being selected as a required dungeon. If this happens, one of the Sacred Power checks will be chosen as the "goal location". Players can see what this location is by talking to the stone statue added to the 1st Sky Keep room opposite the bird statue.

The Fi "required dungeons" text has been updated. The "all dungeons" message shows if there are 7 required dungeons or if there are 6 and Sky Keep is disabled.

## How did/do you test these changes?
I generated many seeds with various combinations of the Sky Keep, required dungeons, and BUD settings.
* Sky Keep enabled + BUD off can lead to important items being placed inside Sky Keep even when it wasn't selected as a required dungeon.
* Sky Keep enabled + BUD on ensures Sky Keep is barren when not selected as a required dungeon. 
* Sky Keep disabled always makes Sky Keep barren.

## Notes
* I was getting the "Sacred Power of Nayru" goal location a lot. Not sure if this is a bias in the selection or I just got rando'd
* I had to change the seed for the max ER test because the old one fails with the extra setting in the setting string. The error can be seen here: https://github.com/CovenEsme/sshd-rando/actions/runs/10009882544/job/27669760982
