### PR TITLE
Improve Release Artifact Uploading

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,13 +119,13 @@ jobs:
       # Archive and upload artifacts
       - name: Tar Files if not Windows Build
         if: runner.os != 'Windows'
-        run: tar -C "dist/release_archive_${{ steps.read_toml.outputs.value }}_${{ matrix.artifact }}/" -cvf "Skyward Sword HD Randomizer v${{ steps.read_toml.outputs.value }} (${{ matrix.artifact }}${{ matrix.artifact_suffix }}).tar" .
+        run: tar -C "dist/release_archive_${{ steps.read_toml.outputs.value }}_${{ matrix.artifact }}/" -cvf "Skyward_Sword_HD_Randomizer_v${{ steps.read_toml.outputs.value }}_${{ matrix.artifact }}${{ matrix.artifact_suffix }}.tar" .
       - name: Upload non-Windows Artifact
         if: runner.os != 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: Skyward Sword HD Randomizer v${{ steps.read_toml.outputs.value }} (${{ matrix.artifact }}${{ matrix.artifact_suffix }})
-          path: Skyward Sword HD Randomizer v${{ steps.read_toml.outputs.value }} (${{ matrix.artifact }}${{ matrix.artifact_suffix }}).tar
+          path: Skyward_Sword_HD_Randomizer_v${{ steps.read_toml.outputs.value }}_${{ matrix.artifact }}${{ matrix.artifact_suffix }}.tar
       - name: Upload Windows Artifact
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,14 +29,27 @@ jobs:
         with:
           run-id: ${{ github.run_id }}
           github-token: ${{ github.token }}
-          merge-multiple: true
+      
+      - name: Read Version
+        uses: SebRollen/toml-action@v1.2.0
+        id: read_toml
+        with:
+          file: "constants/randoconstants.py"
+          field: "VERSION"
+
+      - name: Zip windows build
+        run: |
+          cd "Skyward Sword HD Randomizer v${{ steps.read_toml.outputs.value }} (windows)"
+          zip "Skyward_Sword_HD_Randomizer_v${{ steps.read_toml.outputs.value }}_windows.zip" ./* -r
+          rm *.exe
+          cd ..
       
       # filter the artifacts by name, ignoring the version
       - name: Filter artifacts
         id: filter_artifacts
         run: |
           echo 'builds<<EOF' >> $GITHUB_OUTPUT
-          echo "$(find . -name "Skyward Sword HD Randomizer*")" >> $GITHUB_OUTPUT
+          echo "$(find . -name "Skyward_Sword_HD_Randomizer*")" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
   
       # create a release


### PR DESCRIPTION
## What does this address?
* Fixes the issue where releases would only have an exe for the windows build instead of the zip file containing the directory structure + misc files
* Renames build artifacts to use underscores instead of spaces so that release artifacts get names `Skyward_Sword_HD_Randomizer...` instead of `Skyward.Sword.HD.Randomizer...`


## How did/do you test these changes?
I tested the specific changes needed in a separate branch before consolidating it into this new one. I created a test release on my fork to show how it now works which can be found here: https://github.com/CovenEsme/sshd-rando/releases/tag/ver0.0
