### PR TITLE
Unlink FW and FFW bird statues

### DIFF
--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -340,13 +340,15 @@
 - name: Flooded Faron Woods
   hint_region: Flooded Faron Woods
   events:
-    Unlock In the Woods Statue: Water_Dragons_Scale
-    Unlock Viewing Platform Statue: Water_Dragons_Scale
-    Unlock Faron Woods Entry Statue: Water_Dragons_Scale
-    Unlock The Great Tree Statue: Clawshots or Water_Dragons_Scale
     Retrieve Oolo: Scrapper and 'Start_Owlans_Quest'
     Can Watch Completed Tadtones Cutscene: Nothing
     Can Collect Water: Bottle
+    # Leads to some obscure logic when paired with the Groosenator
+    #
+    # Unlock In the Woods Statue: Water_Dragons_Scale
+    # Unlock Viewing Platform Statue: Water_Dragons_Scale
+    # Unlock Faron Woods Entry Statue: Water_Dragons_Scale
+    # Unlock The Great Tree Statue: Clawshots or Water_Dragons_Scale
   exits:
     Sealed Grounds: Nothing # Talk to Bucha
     Flooded Great Tree Upper: Clawshots


### PR DESCRIPTION
## What does this address?
Removes the ability to unlock the Faron Woods bird statues from Flooded Faron Woods. This removes the obscure logic that can arise because of the Groosenator:
* Use the Groosenator -> FFW
* Use scale/claws to activate the bird statue
* Fly out and back in to land at the normal Great Tree statue
* Drop down and gain access to the rest of Faron Woods


## How did/do you test these changes?
* Created a seed with no starting items or starting sword
* Load a new tracker and mark the Emerald Tablet and the Water Dragon's Scale
* See that only the following checks are in logic:
    * `Sealed Temple - Chest near The Old One`
    * `Inside the Flooded Great Tree - Rupee behind Breakable Rocks near Dragon's Tail 1`
    * `Inside the Flooded Great Tree - Rupee behind Breakable Rocks near Dragon's Tail 2`
* Ensure that the rest of Faron Woods's checks cannot be accessed without needing a Sword or Clawshots to get past the bamboo at the start