### PR TITLE
Fix typo in description of SSH mast skip trick

### DIFF
--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -1675,7 +1675,7 @@
     - "On"
   options:
     - "off": "You will only be expected to get the Sandship - Chest at Ship's Stern by using the Clawshots."
-    - "on": "You may need to get the Sandship - Chest at Ship's Stern by side-hopping from the to of the mast."
+    - "on": "You may need to get the Sandship - Chest at Ship's Stern by side-hopping from the top of the mast."
 
 - name: logic_sandship_itemless_spume
   default_option: "off"


### PR DESCRIPTION
## What does this address?
Fixes a typo is the description of the `logic_sandship_jump_to_stern` setting :p