### PR TITLE
Fix strange hint wordings

### DIFF
--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -2204,12 +2204,12 @@
 - name: Isle of Songs - Strike Crest with Goddess Sword
   standard: Isle of Songs - Strike Crest with Goddess Sword
   pretty: Isle of Songs - Strike Crest with Goddess Sword
-  cryptic: the <r<goddess' blade>> reveals
+  cryptic: the <r<goddess' blade>>
 
 - name: Isle of Songs - Strike Crest with Longsword
   standard: Isle of Songs - Strike Crest with Longsword
   pretty: Isle of Songs - Strike Crest with Longsword
-  cryptic: a <r<longsword>> reveals
+  cryptic: a <r<longsword>>
 
 - name: Isle of Songs - Strike Crest with White Sword
   standard: Isle of Songs - Strike Crest with White Sword
@@ -3015,7 +3015,7 @@
 - name: Flooded Faron Woods - Water Dragon's Reward
   standard: Flooded Faron Woods - Water Dragon's Reward
   pretty: Flooded Faron Woods - Water Dragon's Reward
-  cryptic: completing a <r<watery song>> reveals
+  cryptic: completing a <r<watery song>>
 
 - name: Eldin Volcano - Rupee on Ledge before First Room
   standard: Eldin Volcano - Rupee on Ledge before First Room


### PR DESCRIPTION
## What does this address?
Fixes the strange hint wordings where some hint text ended in the word "reveals". This doubled up with the standard hint text.

E.g. "They say that completing a <r<watery song>> reveals rewards <item_pretty_or_cryptic_name>."