### PR TITLE
Fix some beatable only logic issues

### DIFF
--- a/logic/hints.py
+++ b/logic/hints.py
@@ -583,7 +583,14 @@ def assign_gossip_stone_hints(
     # Keep trying to place hints until all have been logically placed
     # at least once
     successfully_placed_hints = False
+    retry_count = 50
     while not successfully_placed_hints:
+        retry_count -= 1
+        if retry_count < 0:
+            raise RuntimeError(
+                "Failed to properly place gossip stone hints. Try using a different seed for generation."
+            )
+
         random.shuffle(hint_locations)
         successfully_placed_hints = True
         for stone in gossip_stone_locations:


### PR DESCRIPTION
## What does this address?

The reworking of choosing goal locations failed to account for some beatable only logic scenarios. Currently, goal locations can lose their goal location status if their unreachable in beatable only logic. This means that it's possible for a dungeon to not be assigned a goal location, and dungeons without goal locations can never be chosen as required dungeons. The fixes here properly account for this scenario.

There's also a deeper issue with assigning gossip stone hints in beatable only logic currently, but it should be pretty rare so I've just thrown in a runtime exception that gets raised if it's clear that the randomizer is unable to place gossip stone hints properly for the time being.

## How did/do you test these changes?

I tested all the seeds that goldendevil posted which threw errors and they all generated fine.

## Notes
For an example which fails gossip stone hint generation, here's a 1.2 permalink: `U1NIRFItMS4yADEAR3Jvb3NlTHV2Q2ljYWRhS2FyYW5lADpXhaoVBaZZiA5oQSMiKBgCAjAZAUCIAAAAAAAgAAAACAAAAAAACAABQVAA8njwJn9EGAAwQADBvwHoAAACAP///z//fDbgfkb8xf4AwP/A/8CM/z+A//8A5//A/w/8EOCYwA4eYALAeAAwAADQNnAMwHFAgAH/GcCA4ebBAAAYBwAAAADgA/oB8AAAAPwAAAAABAAAwAMAAAAA0BY=`
