### PR TITLE
Fix dungeon rewards not appearing on the tracker

### DIFF
--- a/logic/area.py
+++ b/logic/area.py
@@ -246,7 +246,9 @@ def assign_hint_regions_and_dungeon_locations(starting_area: Area):
             if region in dungeon_regions:
                 locations = [la.location for la in area.locations]
                 dungeon = area.world.get_dungeon(region)
-                dungeon.locations.extend(locations)
-                logging.getLogger("").debug(
-                    f"{[l.name for l in locations]} have been assigned to dungeon {region}"
-                )
+                for loc in locations:
+                    if loc not in dungeon.locations:
+                        dungeon.locations.append(loc)
+                        logging.getLogger("").debug(
+                            f"{loc} has been assigned to dungeon {region}"
+                        )


### PR DESCRIPTION
## What does this address?

I'm not sure why this wasn't a problem before, but somehow some end of dungeon locations were being added to a dungeon's location list twice and that was screwing with the `eud_progression` variable.

## How did/do you test these changes?

I manually checked to make sure all the end of dungeon locations were being properly shown.

