### PR TITLE
Fix some dungeon locations not being properly assigned

### DIFF
--- a/logic/area.py
+++ b/logic/area.py
@@ -237,7 +237,9 @@ def assign_hint_regions_and_dungeon_locations(starting_area: Area):
     # if there are any dungeon regions
     for region in hint_regions:
         if region in dungeon_regions:
-            locations = [la.location for la in area.locations]
+            locations = [
+                la.location for area in already_checked for la in area.locations
+            ]
             dungeon = area.world.get_dungeon(region)
             for loc in locations:
                 if loc not in dungeon.locations:


### PR DESCRIPTION
## What does this address?

Some dungeon locations were not getting properly assigned to their dungeons. The problem was that when assigning hint regions and dungeon locations, we were only assigning locations which were in the last checked area in the loop. This change goes through and checks all areas that had been tested in the entire loop. This was noticeable in the tracker as these locations would appear under their dungeons even if their dungeons were barren when Unrequired Dungeons are Barren was on.

## How did/do you test these changes?

I clicked through all the dungeons on the tracker with Unrequired Dungeons are Barren on and all the locations appeared when the dungeon was active, and disappeared when the dungeon was not active.

