### PR TITLE
Fix logic for exiting thunderhead

### DIFF
--- a/data/world/Sky.yaml
+++ b/data/world/Sky.yaml
@@ -285,7 +285,7 @@
     Isle of Songs: Nothing
     Mogma Mitts Island: Nothing
     Bug Heaven: Nothing
-    The Sky: Nothing
+    The Sky: (Goddesss_Harp and Ballad_of_the_Goddess and can_access(Central Skyloft)) or open_thunderhead == on
   locations:
     Inside the Thunderhead - Song from Levias: Spiral_Charge and Scrapper and Sword and 'Pick_up_Levias_Soup'
     Inside the Thunderhead - Gossip Stone near Bug Heaven: Nothing

--- a/logic/area.py
+++ b/logic/area.py
@@ -147,7 +147,7 @@ class Area:
 
                     # Only add entrances which fit the following criteria
                     # - The entrance is shuffled and not impossible
-                    # - The entrance is decoupled or the entrance insn't connected or the entrance's replaced reverse hasn't been added yet
+                    # - The entrance is decoupled or the entrance isn't connected or the entrance's replaced reverse hasn't been added yet
                     if (
                         entrance.shuffled
                         and entrance.requirement.type != RequirementType.IMPOSSIBLE

--- a/logic/fill.py
+++ b/logic/fill.py
@@ -69,7 +69,7 @@ def fill_worlds(worlds: list[World]):
 
 # Assumed fill is an algorithm which statistically places items more
 # evenly across the world compared to forward fill. The idea is that
-# we first startwith all the items, take an item out, search for
+# we first start with all the items, take an item out, search for
 # available locations (picking up any placed items along the way),
 # and choose a random location of the available ones to place the item.
 # Repeat for all items in the items_to_place_list.
@@ -171,7 +171,7 @@ def assumed_fill(
             rollbacks.append(spot_to_fill)
 
 
-# Place the items in items_to_place completel randomly within the allowed locations.
+# Place the items in items_to_place completely randomly within the allowed locations.
 # There are no logic checks with this fill.
 def fast_fill(items_to_place: list[Item], allowed_locations: list[Location]) -> None:
     empty_locations = [


### PR DESCRIPTION
## What does this address?

Previously there weren't any requirements for exiting thunderhead because I erroneously assumed the loading zone to leave was always active. This is actually not the case and so the logic statement has been changed to reflect the same requirements for entering thunderhead.


