### PR TITLE
Fix incorrect time of day logic for the Bazaar

### DIFF
--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -250,7 +250,7 @@
     Central Skyloft - West Rupee in Bird's Nest: Nothing
 
 - name: Bazaar
-  allowed_time_of_day: All
+  allowed_time_of_day: Day Only
   events:
     Obtain Stamina Potion: Bottle and Raise_Lanayru_Mining_Facility
     # important Tracker events
@@ -272,19 +272,19 @@
     # Bazaar - Upgrade to Big Bug Net: Bug_Net and 'Can_Play_Clean_Cut_Minigame'
 
 - name: Bazaar North
-  allowed_time_of_day: All
+  allowed_time_of_day: Day Only
   exits:
     Bazaar: Nothing
     Central Skyloft: Nothing
 
 - name: Bazaar South
-  allowed_time_of_day: All
+  allowed_time_of_day: Day Only
   exits:
     Bazaar: Nothing
     Central Skyloft: Nothing
 
 - name: Bazaar West
-  allowed_time_of_day: All
+  allowed_time_of_day: Day Only
   exits:
     Bazaar: Nothing
     Central Skyloft: Nothing

--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -519,12 +519,16 @@ def set_plandomizer_entrances(
                 entrance_type = entrance_to_connect.type
             else:
                 raise EntranceShuffleError(
-                    f"Entrance {entrance}'s type is not being shuffled and thus can't be plandomized"
+                    f"Entrance {entrance}'s type ({entrance.type}) is not being shuffled and thus can't be plandomized"
                 )
 
         # Get the appropriate pools
         entrance_pool = entrance_pools[entrance_type]
         target_pool = target_entrance_pools[entrance_type]
+
+        if entrance_to_connect.reverse in entrance_pool:
+            entrance_to_connect = entrance_to_connect.reverse
+            target_to_connect = target_to_connect.reverse
 
         if entrance_to_connect in entrance_pool:
             valid_target_found = False
@@ -546,7 +550,7 @@ def set_plandomizer_entrances(
                 )
         else:
             raise EntranceShuffleError(
-                f"Entrance {entrance}'s type is not being shuffled and thus can't be plandomized"
+                f"Entrance {entrance}'s type ({entrance.type}) is not being shuffled and thus can't be plandomized"
             )
 
     logging.getLogger("").debug("All plandomizer entrances have been placed")


### PR DESCRIPTION
## What does this address?

Fixes the issue where the randomizer believed that the nighttime state could be carried through the Bazaar.

Also fixes a missed case when reading entrances from plando files

## How did/do you test these changes?

I used a plandomizer file to bind the after waterfall cave entrance to one of the Bazaar entrances:

```yaml
World 1:
  entrances:
    Waterfall Cave -> Skyloft Past Waterfall Cave: Central Skyloft from Bazaar North
```

Before the fix, this was valid and the randomizer accepted this input. After the fix, the randomizer throws the following error (truncated for readability):

```py
Shuffling entrances for World 1...
Missing locations:
 ['Central Skyloft - Crystal after Waterfall Cave', 'Central Skyloft - Crystal in Loftwing Prison']
Traceback (most recent call last):
...
logic.entrance_shuffle.EntranceShuffleError: Not all logic is satisfied!
```
