### PR TITLE
Prevent Sacred Water setting sceneflags

### DIFF
--- a/data/patches/eventpatches.yaml
+++ b/data/patches/eventpatches.yaml
@@ -596,6 +596,16 @@
     index: 520
     flow:
       next: -1
+  - name: Prevent Sacred Water setting flags 1
+    type: flowpatch
+    index: 155
+    flow:
+      next: 156
+  - name: Prevent Sacred Water setting flags 2
+    type: flowpatch
+    index: 156
+    flow:
+      next: -1
   # - name: Set GoT flags on MS
   #   type: flowpatch
   #   index: 74


### PR DESCRIPTION
## What does this address?

Fixes the issue where collecting Sacred Water in the Sealed Grounds spiral would start a Groosenator event.


## How did/do you test these changes?

I plando'd a Sacred Water bottle onto one of the stamina fruits in the Sealed Grounds spiral. I verified the issue and verified that this patch prevents the event being triggered :p