### PR TITLE
Add clearer error msg when too few dungeons are inaccessible in ER

### DIFF
--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -57,18 +57,6 @@ def shuffle_world_entrances(world: World, worlds: list[World]):
                     f"Removing {location} as goal location due to it being unreachable"
                 )
 
-                for d in world.dungeons.values():
-                    goal_location_found = False
-
-                    for l in d.locations:
-                        if l.is_goal_location:
-                            goal_location_found = True
-
-                    if not goal_location_found:
-                        raise EntranceShuffleError(
-                            f"Could not generate seed because '{location}' could not be accessed and there are now not enough goal locations.<br><br>\nIf you are playing with randomized entrances, try changing your seed and re-randomizing.<br><br>\nIf not, please report this error on Discord or GitHub."
-                        )
-
 
 def set_all_entrances_data(world: World) -> None:
     with open(ENTRANCE_SHUFFLE_DATA_PATH, encoding="utf-8") as entrance_data_file:

--- a/logic/entrance_shuffle.py
+++ b/logic/entrance_shuffle.py
@@ -57,6 +57,18 @@ def shuffle_world_entrances(world: World, worlds: list[World]):
                     f"Removing {location} as goal location due to it being unreachable"
                 )
 
+                for d in world.dungeons.values():
+                    goal_location_found = False
+
+                    for l in d.locations:
+                        if l.is_goal_location:
+                            goal_location_found = True
+
+                    if not goal_location_found:
+                        raise EntranceShuffleError(
+                            f"Could not generate seed because '{location}' could not be accessed and there are now not enough goal locations.<br><br>\nIf you are playing with randomized entrances, try changing your seed and re-randomizing.<br><br>\nIf not, please report this error on Discord or GitHub."
+                        )
+
 
 def set_all_entrances_data(world: World) -> None:
     with open(ENTRANCE_SHUFFLE_DATA_PATH, encoding="utf-8") as entrance_data_file:

--- a/logic/search.py
+++ b/logic/search.py
@@ -414,7 +414,7 @@ def all_logic_satisfied(worlds: list["World"], item_pool: Counter[Item] = {}) ->
                     or not l.name.startswith("Sky Keep")
                 )
             ]
-            
+
             # Filter so that there's only one sky keep goal location
             found_sky_keep_goal = False
             for loc in accessible_goal_locations.copy():

--- a/logic/search.py
+++ b/logic/search.py
@@ -408,11 +408,21 @@ def all_logic_satisfied(worlds: list["World"], item_pool: Counter[Item] = {}) ->
                 l
                 for l in world.location_table.values()
                 if l.is_goal_location
+                and l in search.visited_locations
                 and (
                     world.setting("dungeons_include_sky_keep") == "on"
                     or not l.name.startswith("Sky Keep")
                 )
             ]
+            
+            # Filter so that there's only one sky keep goal location
+            found_sky_keep_goal = False
+            for loc in accessible_goal_locations.copy():
+                if "Sky Keep" in loc.name and not found_sky_keep_goal:
+                    found_sky_keep_goal = True
+                elif "Sky Keep" in loc.name and found_sky_keep_goal:
+                    accessible_goal_locations.remove(loc)
+
             if (
                 world.get_game_winning_item() not in search.owned_items
                 or len(accessible_goal_locations)


### PR DESCRIPTION
## What does this address?

Gives a clearer error message when enough dungeon goals are inaccessible to fall below the amount of required dungeons. Golden ran into this issue today on chance and got the following error:
```
Traceback (most recent call last):
  File "gui\guithreads.py", line 29, in run
  File "randomizer\randomize.py", line 17, in randomize
  File "logic\generate.py", line 41, in generate
  File "logic\generate.py", line 94, in generate_randomizer
  File "logic\world.py", line 401, in perform_post_entrance_shuffle_tasks
  File "logic\world.py", line 575, in choose_required_dungeons
RuntimeError: Seed cannot generate because there are not enough dungeons to choose to be required.<br>
The following dungeons must be unrequired with the given settings and/or plandomizer file:<br>
Please change your settings and/or plandomizer file if applicable.
```

The new error more clearly indicates what the actual issue is:
![image](https://github.com/user-attachments/assets/682959a2-15da-468d-9261-c6be286c9f84)


## How did/do you test these changes?

I tested with the seed Golden found the error on and the clearer message showed.