### PR TITLE
Change logic for some stamina fruits in Faron

### DIFF
--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -125,6 +125,8 @@
     Faron Woods Entry Statue: Nothing
     Faron Woods: Can_Cut_Trees_And_Logs or Clawshots or shortcut_logs_near_machi or 'Push_Down_Faron_Woods_Entry_Log' # Either cut trees or clawshot vines
     Behind the Temple: Nothing
+  locations:
+    Faron Woods - Stamina Fruit on Vines below First Log: Beetle
 
 - name: Faron Woods
   hint_region: Faron Woods
@@ -162,7 +164,7 @@
     Faron Woods - Stamina Fruit after Kikwi in Clearing: Nothing
     Faron Woods - Stamina Fruit above Slope Guarded by Deku Baba: Nothing
     Faron Woods - Stamina Fruit on Vines near Erla: Nothing
-    Faron Woods - Stamina Fruit on Vines on Great Tree: Beetle # TODO: Check
+    Faron Woods - Stamina Fruit on Vines on Great Tree: Clawshots or Quick_Beetle
     Faron Woods - Bonk Bamboo Blockade before Kikwi in Clearing: Nothing
     Faron Woods - Slingshot Archway after Kikwi in Clearing: Slingshot
     Faron Woods - Slingshot Archway before Mushroom Grove: Slingshot


### PR DESCRIPTION
## What does this address?

* Changes the logic for the `Faron Woods - Stamina Fruit on Vines on Great Tree` check as using just the beetle is a bit precise (you need to make sure you don't fly too high too early)
* Adds logic to get the `Faron Woods - Stamina Fruit on Vines below First Log` with the beetle if you can't get access to the rest of Faron Woods


## How did/do you test these changes?

I checked the logic using the tracker to verify that just tablet + beetle was sufficient for the vines check and tablet + sword + quick beetle was sufficient for the great tree fruit