### PR TITLE
Fix linux executable name

### DIFF
--- a/build.py
+++ b/build.py
@@ -57,4 +57,7 @@ shutil.copyfile(
     release_archive_path / "sshd_extract" / "README.txt",
 )
 
+if platform.system() == "Linux":
+    base_name.replace(".", "_")
+
 shutil.move(exe_path, release_archive_path / (base_name + exe_ext))

--- a/build.py
+++ b/build.py
@@ -58,6 +58,6 @@ shutil.copyfile(
 )
 
 if platform.system() == "Linux":
-    base_name.replace(".", "_")
+    base_name = base_name.replace(".", "_")
 
 shutil.move(exe_path, release_archive_path / (base_name + exe_ext))


### PR DESCRIPTION
## What does this address?

Renames the build executable on linux to replace all `.` with underscores. This should fix the issue where the randomizer build would be seen as a different file type and wouldn't run correctly.


## How did/do you test these changes?

I generated a build and checked the linux build didn't have any `.` in it.