### PR TITLE
FS event tweaks

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -5764,9 +5764,11 @@ D201_1: # Fire Sanctuary B (inner)
     layer: 0
     room: 1
     objtype: STAG
-  - name: Remove npctke blocking exit from 2nd trapped mogma
+  - name: Remove npctkes in 2nd trapped mogma room
     type: objdelete
-    id: 0xFC16
+    ids:
+      - 0xFC09 # 2nd trapped mogma text
+      - 0xFC16 # can't leave text
     layer: 0
     room: 2
     objtype: OBJ

--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -5764,6 +5764,12 @@ D201_1: # Fire Sanctuary B (inner)
     layer: 0
     room: 1
     objtype: STAG
+  - name: Remove npctke blocking exit from 2nd trapped mogma
+    type: objdelete
+    id: 0xFC16
+    layer: 0
+    room: 2
+    objtype: OBJ
 
 B201: # Ghirahim 2 Boss Room
   # Change FS beaten flag from 13 to 901


### PR DESCRIPTION
## What does this address?

* Removes the initial text when entering the 2nd trapped mogma room where he begs for help
* Removes the text trigger that prevents you from leaving the room until you save the mogma


## How did/do you test these changes?

* I tested entering the room, getting the chest behind bombable wall, and then leaving the room.
* I then re-entered the room and got the 2nd trapped mogma check.