### PR TITLE
Patch chest on post-boko base vs layer

### DIFF
--- a/data/locations.yaml
+++ b/data/locations.yaml
@@ -4086,8 +4086,9 @@
     - Chests
   Paths:
     - event/107-Kanban/Fi give Boko Base Sword item
-    - oarc/F201_2/l0 # boko base stage
-    - oarc/F201_1/l4 # vs stage, post-boko base layer
+    - oarc/F201_2/r0/l0 # boko base stage
+    - oarc/F201_1/r0/l4 # vs stage, post-boko base layer
+    - stage/F201_1/r0/l4/TBox/73 # missing zev prevents the sword pull working on this stage
 
 - name: Bokoblin Base - Chest in Volcano Summit Alcove
   original_item: Progressive Pouch


### PR DESCRIPTION
## What does this address?

Please link to relevant GitHub issues here, if any.

Fixes an issue where, after beating Boko Base, there is an unpatched goddess chest on VS layer 4. This PR makes sure that chest gets patched correctly.

I tried to add the sword to pull on that stage and layer but trying to pull it softlocks. I think it's missing the zev to allow the pull to work. This can be revisited whenever the rando gets support for zev patching :p


## How did/do you test these changes?

I beat boko base and the sword became a chest (not an unpatched goddess chest this time)