### PR TITLE
Hint Importance

### DIFF
--- a/data/items.yaml
+++ b/data/items.yaml
@@ -1322,196 +1322,196 @@
   oarc: null
   game_winning_item: true
   advancement: true
-  
 # Dummy items (for now) to simulate hitting goddess cubes
 - id: 257
   name: Faron Woods Goddess Cube on West Great Tree near Exit
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Central Skyloft - Goddess Chest on West Cliff Island
 - id: 258
   name: Faron Woods Goddess Cube on East Great Tree with Clawshots Target
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Volcanic Island - Inside Goddess Chest
 - id: 259
   name: Faron Woods Goddess Cube on East Great Tree with Rope
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Inside the Thunderhead - Goddess Chest on East Island
 - id: 260
   name: Deep Woods Goddess Cube near Goron
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Lumpy Pumpkin - Goddess Chest near Gossip Stone
 - id: 261
   name: Deep Woods Goddess Cube in front of Skyview
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Island Closest to Faron Pillar - Goddess Chest
 - id: 262
   name: Deep Woods Goddess Cube on top of Skyview
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Beedle's Island - Goddess Chest in Cage
 - id: 263
   name: Lake Floria Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Central Skyloft - Goddess Chest on Island near Waterfall
 - id: 264
   name: Floria Waterfall Goddess Cube on High Ledge
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Fun Fun Island - Goddess Chest below Island
 - id: 265
   name: Eldin Volcano Goddess Cube at Eldin Entrance
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Triple Island - Upper Goddess Chest
 - id: 266
   name: Eldin Volcano Goddess Cube near Mogma Turf Entrance
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Island near Bamboo Island - Top Goddess Chest
 - id: 267
   name: Eldin Volcano Goddess Cube West of Temple
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Bamboo Island - Goddess Chest behind Entrance
 - id: 268
   name: Eldin Volcano Goddess Cube East of Temple
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Northeast Island - Goddess Chest in Cage
 - id: 269
   name: Eldin Volcano Goddess Cube on Sand Slide
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Central Skyloft - Goddess Chest in Shed
 - id: 270
   name: Mogma Turf Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Isle of Songs - Lower Goddess Chest
 - id: 271
   name: Volcano Summit Goddess Cube in Lava Lake
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Inside the Thunderhead - Mogma Mitts Island First Goddess Chest
 - id: 272
   name: Volcano Summit Goddess Cube at Summit Waterfall
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Bug Heaven - Goddess Chest
 - id: 273
   name: Volcano Summit Goddess Cube near Fire Sanctuary Entrance
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Isle of Songs - Top Goddess Chest
 - id: 274
   name: Lanayru Mine Goddess Cube behind First Landing Robot
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Northeast Island - Goddess Chest behind Bombable Rocks
 - id: 275
   name: Lanayru Desert Goddess Cube near Caged Robot
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Triple Island - Lower Goddess Chest
 - id: 276
   name: Lanayru Desert Goddess Cube in Sand Oasis
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Volcanic Island - Outside Goddess Chest
 - id: 277
   name: Lanayru Desert Goddess Cube in Secret Passageway
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Island near Bamboo Island - Goddess Chest in Cave
 - id: 278
   name: Temple of Time Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Beedle's Island - Top Goddess Chest
 - id: 279
   name: Lanayru Gorge Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Inside the Thunderhead - Mogma Mitts Island Second Goddess Chest
 - id: 280
   name: Ancient Harbour Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Bazaar - Goddess Chest
 - id: 281
   name: Skipper's Retreat Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Triple Island - Goddess Chest in Cage
 - id: 282
   name: Pirate Stronghold Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
-
+  goddess_chest: Central Skyloft - Goddess Chest on Waterfall Island
 - id: 283
   name: Skyview Spring Goddess Cube
   types:
-    - Cubes
+    - Goddess Cube
   oarc: null
   advancement: true
+  goddess_chest: Lumpy Pumpkin - Goddess Chest on Roof
 
 
 #####################################################################

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -144,10 +144,6 @@
   shop_arc_name: GetBirdStatue
   shop_model_name: GetBirdStatue
   advancement: true
-  chain_locations:
-   - The Sky - Chest in Breakable Boulder near Fun Fun Island
-   - The Sky - Chest in Breakable Boulder near Lumpy Pumpkin
-   - Inside the Thunderhead - Song from Levias
 - id: 25
   name: Ancient Cistern Boss Key
   types:
@@ -249,16 +245,6 @@
   shop_arc_name: GetGenki
   shop_model_name: GetGenki
   advancement: true
-  chain_locations:
-   - Batreaux's House - 5 Gratitude Crystals Reward
-   - Batreaux's House - 10 Gratitude Crystals Reward
-   - Batreaux's House - 30 Gratitude Crystals Reward
-   - Batreaux's House - 30 Gratitude Crystals Reward Chest
-   - Batreaux's House - 40 Gratitude Crystals Reward
-   - Batreaux's House - 50 Gratitude Crystals Reward
-   - Batreaux's House - 70 Gratitude Crystals First Reward
-   - Batreaux's House - 70 Gratitude Crystals Second Reward
-   - Batreaux's House - 80 Gratitude Crystals Reward
 - id: 36
   name: Glittering Spores
   types:
@@ -298,16 +284,6 @@
   shop_arc_name: GetGenki
   shop_model_name: GetGenki
   advancement: true
-  chain_locations:
-   - Batreaux's House - 5 Gratitude Crystals Reward
-   - Batreaux's House - 10 Gratitude Crystals Reward
-   - Batreaux's House - 30 Gratitude Crystals Reward
-   - Batreaux's House - 30 Gratitude Crystals Reward Chest
-   - Batreaux's House - 40 Gratitude Crystals Reward
-   - Batreaux's House - 50 Gratitude Crystals Reward
-   - Batreaux's House - 70 Gratitude Crystals First Reward
-   - Batreaux's House - 70 Gratitude Crystals Second Reward
-   - Batreaux's House - 80 Gratitude Crystals Reward
 - id: 49
   name: Gust Bellows
   types:
@@ -459,8 +435,6 @@
   shop_arc_name: GetNetA
   shop_model_name: GetNetA
   advancement: true
-  chain_locations:
-   - Bug Heaven - 10 Bugs in 3 Minutes
 - id: 72
   name: Fairy
   types:
@@ -741,11 +715,6 @@
   shop_arc_name: GetPurseB
   shop_model_name: GetPurseB
   advancement: true
-  chain_locations:
-   - Beedle's Airshop - 600 Rupee Item
-   - Beedle's Airshop - 1200 Rupee Item
-   - Beedle's Airshop - 800 Rupee Item
-   - Beedle's Airshop - 1600 Rupee Item
 - id: 109
   name: Big Wallet
   types:
@@ -905,8 +874,6 @@
   shop_arc_name: GetKobunALetter
   shop_model_name: GetKobunALetter
   advancement: true
-  chain_locations:
-   - Knight Academy - Deliver Cawlin's Letter
 - id: 159
   name: Beedle's Insect Cage
   types:
@@ -916,8 +883,6 @@
   shop_arc_name: GetTerryCage
   shop_model_name: GetTerryCage
   advancement: true
-  chain_locations:
-   - Beedle's Island - Deliver Beedle's Insect Cage
 - id: 160
   name: Rattle
   types:
@@ -929,8 +894,6 @@
   shop_arc_name: GetGaragara
   shop_model_name: GetGaragara
   advancement: true
-  chain_locations:
-   - Skyloft Village - Deliver Rattle to Bertie
 - id: 163
   name: Tumbleweed
   types:
@@ -1167,8 +1130,6 @@
   shop_arc_name: GetFruitB
   shop_model_name: GetFruitB
   advancement: true
-  chain_locations:
-   - Lanayru Gorge - Thunder Dragon's Reward
 - id: 199
   name: Extra Wallet
   types:
@@ -1178,11 +1139,6 @@
   shop_arc_name: GetSparePurse
   shop_model_name: GetSparePurse
   advancement: true
-  chain_locations:
-   - Beedle's Airshop - 600 Rupee Item
-   - Beedle's Airshop - 1200 Rupee Item
-   - Beedle's Airshop - 800 Rupee Item
-   - Beedle's Airshop - 1600 Rupee Item
 
 # Custom rando items
 - id: 200
@@ -1322,13 +1278,6 @@
   shop_arc_name: DesertRobot
   shop_model_name: DesertRobot
   advancement: true
-  chain_locations:
-   - Knight Academy - Deliver Kikwi to Owlan
-   - Skyloft Village - Deliver Crystal Ball to Sparrot
-   - Lumpy Pumpkin - Deliver Mogma to Kina
-   - Fun Fun Island - Deliver Party Wheel to Dodoh
-   - Fun Fun Island - 500 Rupees in Dodoh's High Dive
-   - Inside the Thunderhead - Song from Levias
 
 # - id: 240+ == traps
 
@@ -1373,6 +1322,7 @@
   oarc: null
   game_winning_item: true
   advancement: true
+  
 # Dummy items (for now) to simulate hitting goddess cubes
 - id: 257
   name: Faron Woods Goddess Cube on West Great Tree near Exit
@@ -1380,216 +1330,189 @@
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Central Skyloft - Goddess Chest on West Cliff Island
+
 - id: 258
   name: Faron Woods Goddess Cube on East Great Tree with Clawshots Target
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Volcanic Island - Inside Goddess Chest
+
 - id: 259
   name: Faron Woods Goddess Cube on East Great Tree with Rope
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Inside the Thunderhead - Goddess Chest on East Island
+
 - id: 260
   name: Deep Woods Goddess Cube near Goron
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Lumpy Pumpkin - Goddess Chest near Gossip Stone
+
 - id: 261
   name: Deep Woods Goddess Cube in front of Skyview
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Island Closest to Faron Pillar - Goddess Chest
+
 - id: 262
   name: Deep Woods Goddess Cube on top of Skyview
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Beedle's Island - Goddess Chest in Cage
+
 - id: 263
   name: Lake Floria Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Central Skyloft - Goddess Chest on Island near Waterfall
+
 - id: 264
   name: Floria Waterfall Goddess Cube on High Ledge
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Fun Fun Island - Goddess Chest below Island
+
 - id: 265
   name: Eldin Volcano Goddess Cube at Eldin Entrance
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Triple Island - Upper Goddess Chest
+
 - id: 266
   name: Eldin Volcano Goddess Cube near Mogma Turf Entrance
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Island near Bamboo Island - Top Goddess Chest
+
 - id: 267
   name: Eldin Volcano Goddess Cube West of Temple
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Bamboo Island - Goddess Chest behind Entrance
+
 - id: 268
   name: Eldin Volcano Goddess Cube East of Temple
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Northeast Island - Goddess Chest in Cage
+
 - id: 269
   name: Eldin Volcano Goddess Cube on Sand Slide
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Central Skyloft - Goddess Chest in Shed
+
 - id: 270
   name: Mogma Turf Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Isle of Songs - Lower Goddess Chest
+
 - id: 271
   name: Volcano Summit Goddess Cube in Lava Lake
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Inside the Thunderhead - Mogma Mitts Island First Goddess Chest
+
 - id: 272
   name: Volcano Summit Goddess Cube at Summit Waterfall
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Bug Heaven - Goddess Chest
+
 - id: 273
   name: Volcano Summit Goddess Cube near Fire Sanctuary Entrance
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Isle of Songs - Top Goddess Chest
+
 - id: 274
   name: Lanayru Mine Goddess Cube behind First Landing Robot
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Northeast Island - Goddess Chest behind Bombable Rocks
+
 - id: 275
   name: Lanayru Desert Goddess Cube near Caged Robot
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Triple Island - Lower Goddess Chest
+
 - id: 276
   name: Lanayru Desert Goddess Cube in Sand Oasis
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Volcanic Island - Outside Goddess Chest
+
 - id: 277
   name: Lanayru Desert Goddess Cube in Secret Passageway
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Island near Bamboo Island - Goddess Chest in Cave
+
 - id: 278
   name: Temple of Time Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Beedle's Island - Top Goddess Chest
+
 - id: 279
   name: Lanayru Gorge Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Inside the Thunderhead - Mogma Mitts Island Second Goddess Chest
+
 - id: 280
   name: Ancient Harbour Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Bazaar - Goddess Chest
+
 - id: 281
   name: Skipper's Retreat Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Triple Island - Goddess Chest in Cage
+
 - id: 282
   name: Pirate Stronghold Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Central Skyloft - Goddess Chest on Waterfall Island
+
 - id: 283
   name: Skyview Spring Goddess Cube
   types:
     - Cubes
   oarc: null
   advancement: true
-  chain_locations:
-   - Lumpy Pumpkin - Goddess Chest on Roof
+
 
 #####################################################################
 #                      DO NOT USE ITEM ID 511                       #

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -463,6 +463,16 @@
     - "off": "All locations will be treated equally for location hints."
     - "on": "Certain locations which are time-consuming to check will be given priority for location hints."
 
+- name: hint_importance
+  default_option: "off"
+  pretty_name: Hint Importance
+  pretty_options:
+    - "Off"
+    - "On"
+  options:
+    - "off": "Location and item hints will not specify whether or not an item is required."
+    - "on": "Location and item hints will specify if the item hinted at is required, not required, or possibly required. Junk items will not have any specifier, as they are trivially unrequired."
+
 - name: random_starting_statues
   default_option: "off"
   pretty_name: Random Starting Bird Statues

--- a/data/text_data/en_US.yaml
+++ b/data/text_data/en_US.yaml
@@ -253,6 +253,15 @@
 - name: Location Hint
   standard: They say that <location_pretty_or_cryptic_name> rewards <item_pretty_or_cryptic_name>.
 
+- name: Hint Importance Required
+  standard: " (<g+<required>>)"
+
+- name: Hint Importance Possibly Required
+  standard: " (<ye<possibly required>>)"
+
+- name: Hint Importance Not Required
+  standard: " (<s<not required>>)"
+
 - name: Small Key
   standard: Small Key
   pretty: a <Small Key>

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -909,9 +909,7 @@ class Tracker:
                 # Only list goddess cubes whose associated goddess chests aren't excluded
                 if (
                     self.world.setting("goddess_chest_shuffle") == "on"
-                    and self.world.get_location(
-                        location.original_item.chain_locations[0]
-                    ).progression
+                    and location.current_item.get_goddess_chest().progression
                 ):
                     location.progression = True
                     self.items_on_mark[location] = location.current_item

--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::TabShape::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>8</number>
+       <number>5</number>
       </property>
       <widget class="QWidget" name="getting_started_tab">
        <property name="sizePolicy">
@@ -2825,6 +2825,13 @@
             </widget>
            </item>
            <item>
+            <widget class="RandoTriStateCheckBox" name="setting_hint_importance">
+             <property name="text">
+              <string>Hint Importance</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QLabel" name="chest_size_matches_contents_label">
              <property name="text">
               <string>Chest Type Matches Contents (CTMC)</string>
@@ -4332,8 +4339,8 @@ QPushButton {
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>100</width>
-               <height>30</height>
+               <width>546</width>
+               <height>340</height>
               </rect>
              </property>
              <property name="maximumSize">

--- a/gui/ui/ui_custom_theme_dialog.py
+++ b/gui/ui/ui_custom_theme_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'custom_theme_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.2
+## Created by: Qt User Interface Compiler version 6.9.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'main.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.2
+## Created by: Qt User Interface Compiler version 6.9.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -1834,6 +1834,11 @@ class Ui_main_window(object):
 
         self.verticalLayout_23.addWidget(self.setting_impa_sot_hint)
 
+        self.setting_hint_importance = RandoTriStateCheckBox(self.hints_group_box)
+        self.setting_hint_importance.setObjectName(u"setting_hint_importance")
+
+        self.verticalLayout_23.addWidget(self.setting_hint_importance)
+
         self.chest_size_matches_contents_label = QLabel(self.hints_group_box)
         self.chest_size_matches_contents_label.setObjectName(u"chest_size_matches_contents_label")
 
@@ -2865,7 +2870,7 @@ class Ui_main_window(object):
         self.tracker_locations_scroll_area.setWidgetResizable(True)
         self.tracker_locations_scroll_widget = QWidget()
         self.tracker_locations_scroll_widget.setObjectName(u"tracker_locations_scroll_widget")
-        self.tracker_locations_scroll_widget.setGeometry(QRect(0, 0, 100, 30))
+        self.tracker_locations_scroll_widget.setGeometry(QRect(0, 0, 546, 340))
         self.tracker_locations_scroll_widget.setMaximumSize(QSize(546, 16777215))
         self.tracker_locations_scroll_layout = QHBoxLayout(self.tracker_locations_scroll_widget)
         self.tracker_locations_scroll_layout.setSpacing(0)
@@ -3008,7 +3013,7 @@ class Ui_main_window(object):
 
         self.retranslateUi(main_window)
 
-        self.tab_widget.setCurrentIndex(8)
+        self.tab_widget.setCurrentIndex(5)
 
 
         QMetaObject.connectSlotsByName(main_window)
@@ -3211,6 +3216,7 @@ class Ui_main_window(object):
         self.setting_always_hints.setText(QCoreApplication.translate("main_window", u"Prioritize Remote Location Hints", None))
         self.setting_cryptic_hint_text.setText(QCoreApplication.translate("main_window", u"Cryptic Hint Text", None))
         self.setting_impa_sot_hint.setText(QCoreApplication.translate("main_window", u"Past Impa Stone of Trials Hint", None))
+        self.setting_hint_importance.setText(QCoreApplication.translate("main_window", u"Hint Importance", None))
         self.chest_size_matches_contents_label.setText(QCoreApplication.translate("main_window", u"Chest Type Matches Contents (CTMC)", None))
         self.setting_small_keys_in_fancy_chests.setText(QCoreApplication.translate("main_window", u"Small Keys in Fancy Chests", None))
         self.tab_widget.setTabText(self.tab_widget.indexOf(self.hints_tab), QCoreApplication.translate("main_window", u"Hints", None))

--- a/logic/generate.py
+++ b/logic/generate.py
@@ -9,6 +9,7 @@ from .spoiler_log import generate_spoiler_log, generate_anti_spoiler_log
 from .plandomizer import load_plandomizer_data
 from .entrance_shuffle import shuffle_world_entrances
 from .hints import generate_hints
+from .tooltips.tooltips import flatten_world_requirements
 from util.text import load_text_data
 
 from gui.dialogs.dialog_header import print_progress_text, update_progress_value
@@ -106,6 +107,8 @@ def generate_randomizer(config: Config) -> list[World]:
 
     for world in worlds:
         world.perform_post_entrance_shuffle_tasks()
+        print_progress_text(f"Flattening {world}...")
+        flatten_world_requirements(world)
 
     update_progress_value(16)
     print_progress_text("Filling Worlds...")

--- a/logic/hints.py
+++ b/logic/hints.py
@@ -219,7 +219,7 @@ def calculate_possible_barren_regions(worlds: list[World]) -> None:
                 ]
             ):
                 loc.importance = LocationImportance.NOT_REQUIRED
-            # Locations which are on the path to Ganondorf are required.
+            # Locations which are on the path to Demise are required.
             elif loc in defeat_demise_path_locs or loc == defeat_demise:
                 loc.importance = LocationImportance.REQUIRED
 
@@ -914,7 +914,7 @@ def generate_song_hints(world: World, hint_locations: list[Location]) -> None:
                 else:
                     # There's only enough text space to hint at one full item name.
                     hinted_location = None
-                    # If there are any logically required items (on the path to Ganondorf), choose one of them at random
+                    # If there are any logically required items (on the path to Demise), choose one of them at random
                     random.shuffle(useful_locations)
                     for location in useful_locations:
                         if location.importance == LocationImportance.REQUIRED:

--- a/logic/hints.py
+++ b/logic/hints.py
@@ -115,12 +115,7 @@ def sanitize_major_items(worlds: list[World]) -> None:
                 or (
                     # If all of this item's chain locations are not progression, then
                     # the item is not a major item.
-                    all(
-                        [
-                            True if not world.get_location(loc).progression else False
-                            for loc in item.chain_locations
-                        ]
-                    )
+                    all([not loc.progression for loc in item.chain_locations])
                     and len(item.chain_locations) > 0
                 )
             ):
@@ -135,14 +130,14 @@ def calculate_possible_path_locations(worlds: list[World]) -> None:
     # First generate the goal location keys and also remove items from non-
     # progress locations since they shouldn't be considered when determining
     # path locations
-    non_required_locations = {}
+    non_required_locations: dict[Location, Item] = {}
     for world in worlds:
         # Defeat Demise is always a goal location
-        world.path_locations[world.get_location("Hylia's Realm - Defeat Demise")] = []
+        world.goal_locations.append(world.get_location("Hylia's Realm - Defeat Demise"))
         # Required dungeons also have goal locations
         for dungeon in world.dungeons.values():
             if dungeon.required:
-                world.path_locations[dungeon.goal_location] = []
+                world.goal_locations.append(dungeon.goal_location)
 
         for location in world.location_table.values():
             if not location.progression and not (
@@ -152,61 +147,48 @@ def calculate_possible_path_locations(worlds: list[World]) -> None:
                 non_required_locations[location] = location.current_item
                 location.remove_current_item()
 
-    # Determine path locations for each goal location by going through the playthrough
-    # and seeing if taking away the item at each location can still access the goal location(s)
+    # Determine path locations for every progression location with a major item by going through
+    # and seeing if taking away the item at each location can still access the other locations
     for world in worlds:
-        for sphere in worlds[0].playthrough_spheres:
-            for location in sphere:
-                item_at_location = location.current_item
+        for potential_path_location in world.get_all_item_locations():
+            item_at_location = potential_path_location.current_item
 
-                # TODO: how can an item_at_location even be null here?
-                if item_at_location is None:
-                    continue
+            # Skip over locations with removed items
+            if item_at_location is None:
+                continue
 
-                # If this location has a small or big key and the key is known to be within the dungeon,
-                # then ignore it because the player already knows where those items are. Also ignore race
-                # mode locations at the end of dungeons because players know those locations are required.
-                if (
-                    location.has_known_vanilla_item
-                    or location.is_goal_location
-                    or (
-                        item_at_location.is_dungeon_small_key
-                        and world.setting("small_keys").is_any_of(
-                            "own_dungeon", "own_region"
-                        )
-                    )
-                    or (
-                        item_at_location.is_boss_key
-                        and world.setting("boss_keys").is_any_of(
-                            "own_dungeon", "own_region"
-                        )
-                    )
-                ):
-                    continue
+            # If this location is not a progression location with a major item, continue
+            if not (
+                potential_path_location.progression and item_at_location.is_major_item
+            ):
+                continue
 
-                # Take the item away from the location
-                location.remove_current_item()
+            # Take the item away from the location
+            potential_path_location.remove_current_item()
 
-                # Run a search without the item
-                search = Search(SearchMode.ACCESSIBLE_LOCATIONS, worlds)
-                search.search_worlds()
+            # Run a search without the item
+            search = Search(SearchMode.ACCESSIBLE_LOCATIONS, worlds)
+            search.search_worlds()
 
-                # If we never reach the goal location, then this location is
-                # "on the path to" the goal location.
-                for goal_location, path_locations in world.path_locations.items():
-                    if goal_location not in search.visited_locations:
-                        path_locations.append(location)
+            # Check to see if we can reach each progression location. For each progression location that we can't reach,
+            # add the potential path location as a path location
+            for location in world.location_table.values():
+                if location not in search.visited_locations:
+                    location.path_locations.append(potential_path_location)
+                    # logging.getLogger("").debug(
+                    #     f"{potential_path_location} is now path to {location} ({item_at_location})"
+                    # )
 
-                # Then give back the location's item
-                location.set_current_item(item_at_location)
+            # Then give back the location's item
+            potential_path_location.set_current_item(item_at_location)
 
         # logging.getLogger("").debug(f"Path locations for {world}")
-        # for goal_location, path_locations in world.path_locations.items():
+        # for goal_location in world.path_locations:
         #     goal_name = get_text_data(goal_location.name, "goal_name").get(
         #         "en_US"
         #     )
         #     logging.getLogger("").debug(f"  {goal_name}")
-        #     for location in path_locations:
+        #     for location in goal_location.path_locations:
         #         logging.getLogger("").debug(f"  - {location}: {location.current_item}")
 
     # Give back non-progress items
@@ -217,88 +199,153 @@ def calculate_possible_path_locations(worlds: list[World]) -> None:
 def calculate_possible_barren_regions(worlds: list[World]) -> None:
     logging.getLogger("").debug("Calculating Barren Regions")
     for world in worlds:
-        potentially_junk_locations = set()
-        junk_locations = set()
-        for location in world.get_all_item_locations():
+        defeat_demise = world.get_location("Hylia's Realm - Defeat Demise")
+        defeat_demise_path_locs = set(defeat_demise.path_locations)
+
+        for loc in world.get_all_item_locations():
             # If this location is progression, then add its hint regions to
             # the set of potentially barren regions
-            if location.progression:
-                for loc_access in location.loc_access_list:
+            if loc.progression:
+                for loc_access in loc.loc_access_list:
                     for hint_region in loc_access.area.hint_regions:
                         world.barren_regions[hint_region] = []
 
-            # Prevent small keys and big keys in known places from being barren blockers
-            item_at_location = location.current_item
-            if (
-                location.is_goal_location
-                or (
-                    item_at_location.is_dungeon_small_key
-                    and world.setting("small_keys").is_any_of("vanilla", "own_dungeon")
-                )
-                or (
-                    item_at_location.is_boss_key
-                    and world.setting("boss_keys").is_any_of("vanilla", "own_dungeon")
-                )
-            ):
-                junk_locations.add(location)
-            # Depending on how items were placed, temporarily set certain
-            # items as junk items if all of the item's chain locations also
-            # only contain junk
-            chain_locations = [
-                world.get_location(loc_name)
-                for loc_name in location.current_item.chain_locations
-            ]
-            if location.progression and len(chain_locations) > 0:
-                if locations_are_all_junk(chain_locations):
-                    junk_locations.add(location)
-                    logging.getLogger("").debug(f"{location.current_item} is now junk")
-                else:
-                    potentially_junk_locations.add(location)
-
-        # Iterate through all the potentially_junk_locations until
-        # no new junk locations are set
-        new_junk_locations = True
-        while new_junk_locations:
-            new_junk_locations = False
-            for location in potentially_junk_locations:
-                chain_locations = [
-                    world.get_location(loc_name)
-                    for loc_name in location.current_item.chain_locations
+            # Set locations that we can easily calculate as not required or required right now.
+            # Locations which contain barren items, or whose chain locations all contain barren items are not required.
+            if not loc.current_item.is_major_item or all(
+                [
+                    not c.current_item.is_major_item
+                    for c in loc.current_item.chain_locations
                 ]
-                if location.current_item.is_major_item and locations_are_all_junk(
-                    chain_locations
-                ):
-                    new_junk_locations = True
-                    junk_locations.add(location)
-                    logging.getLogger("").debug(f"{location.current_item} is now junk")
+            ):
+                loc.importance = LocationImportance.NOT_REQUIRED
+            # Locations which are on the path to Ganondorf are required.
+            elif loc in defeat_demise_path_locs or loc == defeat_demise:
+                loc.importance = LocationImportance.REQUIRED
+
+        # Any location in the playthrough which doesn't have a hint importance set yet is going to be possibly required
+        for sphere in worlds[0].playthrough_spheres:
+            for loc in sphere:
+                if loc.importance == LocationImportance.UNKNOWN:
+                    loc.importance = LocationImportance.POSSIBLY_REQUIRED
+                    logging.getLogger("").debug(
+                        f"{loc}: {loc.current_item} is possibly required due to appearing in playthrough"
+                    )
+
+        # Any remaining locations which don't have a hint importance set yet are either possibly required or not required.
+        # These locations' hint importance take much longer to calculate
+        for loc in world.get_all_item_locations():
+            if loc.importance == LocationImportance.UNKNOWN:
+                if blocking_location := calculate_location_hint_importance(loc):
+                    logging.getLogger("").debug(
+                        f"{loc}: {loc.current_item} possibly required due to {blocking_location}: {blocking_location.current_item}"
+                    )
+                else:
+                    logging.getLogger("").debug(
+                        f"{loc}: {loc.current_item} not required"
+                    )
 
         # Now loop through all the progression locations again and remove
-        # any regions from the barren regions which have non-junk items at
-        # any of their locations. Otherwise add the location to the list
-        # of locations in the barren region
-        for location in world.get_all_item_locations():
-            for loc_access in location.loc_access_list:
+        # any regions from the barren regions which have any possibly required or
+        # required items (unless they can be in a barren region). Otherwise add
+        # the location to the list of locations in the barren region
+        for loc in world.get_all_item_locations():
+            if not loc.progression:
+                continue
+
+            for loc_access in loc.loc_access_list:
                 for hint_region in loc_access.area.hint_regions:
-                    if (
-                        location.progression
-                        and location.current_item.is_major_item
-                        and location not in junk_locations
-                        and hint_region in world.barren_regions
-                    ):
-                        del world.barren_regions[hint_region]
-                    elif hint_region in world.barren_regions:
-                        world.barren_regions[hint_region].append(location)
+                    if hint_region in world.barren_regions:
+                        if (
+                            loc.importance == LocationImportance.NOT_REQUIRED
+                            or loc.current_item.can_be_in_barren_region()
+                        ):
+                            world.barren_regions[hint_region].append(loc)
+                        else:
+                            del world.barren_regions[hint_region]
 
         logging.getLogger("").debug(f"Barren regions for {world}")
         for region in world.barren_regions.keys():
             logging.getLogger("").debug(f"- {region}")
 
 
+# Calculates the passed in location's hint importance, as well as recursively calculates the importance of any
+# locations that this one may unlock, but haven't had their own importance calculated yet
+def calculate_location_hint_importance(
+    location: Location, currently_checking: set["Location"] = set()
+) -> Location:
+    # If this location's hint importance is already known, we don't need to calculate it
+    if location.importance != LocationImportance.UNKNOWN:
+        return None
+
+    # Get all the progressive chain locations for this location's item
+    # Filter out locations that aren't progression, are already in this
+    # location's path locations, have an item that we can trivially know
+    # is barren, or have already been deemed as not required.
+    chain_locations = {
+        loc
+        for loc in location.current_item.chain_locations
+        if loc.progression
+        and loc.current_item.is_major_item
+        and loc not in location.path_locations
+        and not loc.current_item.can_be_in_barren_region()
+        and not loc.importance == LocationImportance.NOT_REQUIRED
+    }
+    # Discard the current location, as obviously the item at this location will not lead to itself
+    chain_locations.discard(location)
+
+    # If there are no chain locations left, then this location is not required
+    if len(chain_locations) == 0:
+        location.importance = LocationImportance.NOT_REQUIRED
+        return
+
+    # Get all items from this location's logically required path locations
+    logically_required_items = []
+    for path_location in location.path_locations:
+        logically_required_items.append(path_location.current_item)
+
+    # Perform an importance search to see which locations are reachable without using this item in any way
+    importance_search = Search(
+        SearchMode.LOCATION_IMPORTANCE,
+        location.world.worlds,
+        logically_required_items,
+        importance_location_=location,
+    )
+    importance_search.search_worlds()
+
+    # Any locations that we found can be subtracted out of our chain locations because the item at this location
+    # does not help reach them in any way.
+    chain_locations -= importance_search.visited_locations
+
+    # If any remaining chain locations are also currently being checked for their hint importance,
+    # then we subtract them out. This will allow us to only check locations which aren't potentially
+    # dependent on each other's items. If we go through all of the other locations first and don't
+    # find anything that makes this location possibly required, we'd only be left with locations
+    # currently being checked that are dependent on one another. If these location's items are only
+    # potentially dependent on each other, then they're both not required.
+    chain_locations -= currently_checking
+
+    for loc in chain_locations:
+        # If any remaining chain location hasn't had its hint importance calculated, then do so now
+        if loc.importance == LocationImportance.UNKNOWN:
+            currently_checking.add(location)
+            calculate_location_hint_importance(loc, currently_checking)
+            currently_checking.discard(location)
+        # If any remaining chain location is at least possibly required, then this location is also possibly required
+        if loc.importance != LocationImportance.NOT_REQUIRED:
+            location.importance = LocationImportance.POSSIBLY_REQUIRED
+            return loc
+
+    # If all remaining chain locations were not required, then this location is also not required
+    location.importance = LocationImportance.NOT_REQUIRED
+    return None
+
+
 def generate_path_hint_locations(world: World, hint_locations: list) -> None:
     # Shuffle each pool of path locations so that their orders are random
-    goal_locations_list = []
-    for goal_location, path_locations in world.path_locations.items():
-        random.shuffle(path_locations)
+    goal_locations_list: list[Location] = []
+    for goal_location in world.goal_locations:
+        random.shuffle(goal_location.path_locations)
         # Initially we want to create hints for required dungeon's goal locations
         # and then add Demise in once we have at least 1 hint for each required dungeon
         if goal_location != world.get_location("Hylia's Realm - Defeat Demise"):
@@ -325,15 +372,34 @@ def generate_path_hint_locations(world: World, hint_locations: list) -> None:
 
             goal_location = random.choice(goal_locations_list)
 
-        # If we're placing path hints on gossip stones, don't choose any that somehow
-        # manage to be before every possible gossip stone
         valid_path_locations = [
             loc
-            for loc in world.path_locations[goal_location]
-            if world.setting("path_hints_on_gossip_stones") == "off"
-            or (
-                world.setting("path_hints_on_gossip_stones") == "on"
-                and get_possible_gossip_stones(loc)
+            for loc in goal_location.path_locations
+            # If we're placing path hints on gossip stones, don't choose any that somehow
+            # manage to be before every possible gossip stone
+            if (
+                world.setting("path_hints_on_gossip_stones") == "off"
+                or (
+                    world.setting("path_hints_on_gossip_stones") == "on"
+                    and get_possible_gossip_stones(loc)
+                )
+            )
+            # Also don't choose any locations that are known vanilla items, or small/boss keys in known regions
+            and not (
+                loc.has_known_vanilla_item
+                or loc.is_goal_location
+                or (
+                    loc.current_item.is_dungeon_small_key
+                    and world.setting("small_keys").is_any_of(
+                        "own_dungeon", "own_region"
+                    )
+                )
+                or (
+                    loc.current_item.is_boss_key
+                    and world.setting("boss_keys").is_any_of(
+                        "own_dungeon", "own_region"
+                    )
+                )
             )
         ]
         hint_location = get_hintable_location(valid_path_locations)
@@ -565,8 +631,11 @@ def generate_item_hint_message(location: Location) -> None:
 
     type_ = "cryptic" if world.setting("cryptic_hint_text") == "on" else "pretty"
     item_text_color = "r" if type_ == "pretty" else ""
-    item_text = get_text_data(location.current_item.name, type_).apply_text_color(
-        item_text_color
+    item_text = (
+        get_text_data(location.current_item.name, type_).apply_text_color(
+            item_text_color
+        )
+        + location.generate_importance_text()
     )
 
     full_text = (
@@ -594,7 +663,10 @@ def generate_location_hint_message(location: Location) -> None:
     item = location.current_item
 
     location_text = get_text_data(location.name, type_).apply_text_color(color)
-    item_text = get_text_data(item.name, type_).apply_text_color(color)
+    item_text = (
+        get_text_data(item.name, type_).apply_text_color(color)
+        + location.generate_importance_text()
+    )
 
     full_text = (
         get_text_data("Location Hint")
@@ -804,66 +876,62 @@ def generate_song_hints(world: World, hint_locations: list[Location]) -> None:
         match world.setting("song_hints"):
             case "basic":
                 # If there are any major items in the silent realm
-                if any([loc for loc in locations if loc.current_item.is_major_item]):
+                if any(
+                    [
+                        loc.importance >= LocationImportance.POSSIBLY_REQUIRED
+                        for loc in locations
+                    ]
+                ):
                     hint.text = get_text_data("Trial Useful")
                 else:
                     hint.text = get_text_data("Trial Useless")
 
             case "advanced":
-                # If there are any items on the path to Demise
+                # If there are any required items
                 if any(
-                    [
-                        loc
-                        for loc in locations
-                        if loc
-                        in world.path_locations[
-                            world.get_location("Hylia's Realm - Defeat Demise")
-                        ]
-                    ]
+                    [loc.importance == LocationImportance.REQUIRED for loc in locations]
                 ):
                     hint.text = get_text_data("Trial Required")
-                # If there are any major items in the silent realm
-                elif any([loc for loc in locations if loc.current_item.is_major_item]):
+                # If there are any possibly required item
+                elif any(
+                    [
+                        loc.importance == LocationImportance.POSSIBLY_REQUIRED
+                        for loc in locations
+                    ]
+                ):
                     hint.text = get_text_data("Trial Useful")
                 else:
                     hint.text = get_text_data("Trial Useless")
 
             case "direct":
                 useful_locations = [
-                    loc for loc in locations if loc.current_item.is_major_item
+                    loc
+                    for loc in locations
+                    if loc.importance >= LocationImportance.POSSIBLY_REQUIRED
                 ]
                 if not useful_locations:
                     hint.text = get_text_data("Trial Direct Nothing")
                 else:
-                    # There's only enough text space to hint at one full item name, so calculate which item
-                    # is the most logically useful among the set and display that item name. The most logically
-                    # useful item is whichever item blocks the most checks.
-                    most_useful_location = None
-                    # Keep track of the least amount of locations unlocked so far
-                    unlocked_locations = len(world.location_table) + 1
+                    # There's only enough text space to hint at one full item name.
+                    hinted_location = None
+                    # If there are any logically required items (on the path to Ganondorf), choose one of them at random
+                    random.shuffle(useful_locations)
                     for location in useful_locations:
-                        item_at_location = location.current_item
-                        location.remove_current_item()
+                        if location.importance == LocationImportance.REQUIRED:
+                            hinted_location = location
+                            break
 
-                        search = Search(SearchMode.ACCESSIBLE_LOCATIONS, world.worlds)
-                        search.search_worlds()
-                        # If removing the item at this location leads to fewer unlocked
-                        # locations, then it's the most logically useful
-                        visisted_progression_locations = [
-                            loc for loc in search.visited_locations if loc.progression
-                        ]
-                        if (
-                            len(visisted_progression_locations) < unlocked_locations
-                            or most_useful_location is None
-                        ):
-                            most_useful_location = location
-                            unlocked_locations = len(visisted_progression_locations)
+                    # If there weren't any, just choose any useful location at random.
+                    # The list is already shuffled, so we'll take the first one.
+                    if not hinted_location:
+                        hinted_location = useful_locations[0]
 
-                        location.set_current_item(item_at_location)
-
-                    first_item_text = get_text_data(
-                        f"{most_useful_location.current_item.name}", "pretty"
-                    ).apply_text_color("r")
+                    first_item_text = (
+                        get_text_data(
+                            f"{hinted_location.current_item.name}", "pretty"
+                        ).apply_text_color("r")
+                        + hinted_location.generate_importance_text()
+                    )
                     # If there are still more useful locations in the silent realm, then list how many there are
                     if len(useful_locations) == 1:
                         hint_text_to_append = get_text_data("Trial Direct One").replace(
@@ -874,7 +942,7 @@ def generate_song_hints(world: World, hint_locations: list[Location]) -> None:
                             "<item>", first_item_text
                         )
                     else:
-                        useful_locations.remove(most_useful_location)
+                        useful_locations.remove(hinted_location)
                         hint_text_to_append = (
                             get_text_data("Trial Direct Three Plus")
                             .replace("<item>", first_item_text)
@@ -895,10 +963,6 @@ def generate_song_hints(world: World, hint_locations: list[Location]) -> None:
                     hint.text += hint_text_to_append
 
         logging.getLogger("").debug(f'Generated hint "{hint.text}" for song {song}')
-
-
-def locations_are_all_junk(locations: list[Location]) -> bool:
-    return all([not loc.current_item.is_major_item for loc in locations])
 
 
 def get_hintable_location(locations: list[Location]) -> Location | None:

--- a/logic/item.py
+++ b/logic/item.py
@@ -24,6 +24,7 @@ class Item:
         world_: "World" = None,
         major_item_: bool = False,
         game_winning_item_: bool = False,
+        goddess_chest_: str = None,
     ) -> None:
         self.id: int = id_
         self.name: str = name_
@@ -33,6 +34,7 @@ class Item:
         self.world: "World" = world_
         self.is_major_item: bool = major_item_
         self.is_game_winning_item: bool = game_winning_item_
+        self.goddess_chest: str = goddess_chest_
         self.chain_locations: set["Location"] = set()
         self.was_always_junk: bool = not major_item_
 
@@ -41,6 +43,9 @@ class Item:
         )
         self.is_boss_key: bool = " Boss Key" in name_
         self.is_dungeon_map: bool = " Map" in name_
+
+    def get_goddess_chest(self) -> "Location":
+        return self.world.get_location(self.goddess_chest)
 
     def can_be_in_barren_region(self) -> bool:
         return (

--- a/logic/location.py
+++ b/logic/location.py
@@ -1,6 +1,7 @@
 from logic.requirements import Requirement, RequirementType
 from .item import Item
 from .hint_class import Hint
+from util.text import Text, get_text_data
 
 import logging
 from typing import TYPE_CHECKING
@@ -10,6 +11,13 @@ from constants.itemconstants import GRATITUDE_CRYSTAL
 if TYPE_CHECKING:
     from .world import World
     from .area import LocationAccess
+
+
+class LocationImportance:
+    UNKNOWN: int = 0
+    NOT_REQUIRED: int = 1
+    POSSIBLY_REQUIRED: int = 2
+    REQUIRED: int = 3
 
 
 class Location:
@@ -46,6 +54,8 @@ class Location:
         self.hint_textfile: str = hint_textfile_
         self.hint_textindex: int = hint_textindex_
         self.eventflowindex: int = eventflowindex_
+        self.path_locations: list[Location] = []
+        self.importance: int = LocationImportance.UNKNOWN
 
         # Tracker variables
         self.marked: bool = False
@@ -101,3 +111,22 @@ class Location:
             and self.original_item.name.endswith("Small Key")
             and self.original_item.name != "Lanayru Caves Small Key"
         )
+
+    def generate_importance_text(self) -> Text:
+        # If this item was always junk, or if hint importance is off,
+        # then we won't generate any hint importance text for it
+        if (
+            self.world.setting("hint_importance") == "off"
+            or self.current_item.was_always_junk
+        ):
+            return Text()
+
+        match self.importance:
+            case LocationImportance.REQUIRED:
+                return get_text_data("Hint Importance Required")
+            case LocationImportance.POSSIBLY_REQUIRED:
+                return get_text_data("Hint Importance Possibly Required")
+            case LocationImportance.NOT_REQUIRED:
+                return get_text_data("Hint Importance Not Required")
+            case _:
+                return Text()

--- a/logic/location_table.py
+++ b/logic/location_table.py
@@ -89,7 +89,10 @@ def get_disabled_shuffle_locations(
             )
             or (
                 settings["goddess_chest_shuffle"].value == "off"
-                and "Goddess Chests" in location.types
+                and (
+                    "Goddess Chests" in location.types
+                    or "Goddess Cube" in location.types
+                )
             )
             or (
                 (

--- a/logic/search_mode.py
+++ b/logic/search_mode.py
@@ -1,0 +1,8 @@
+class SearchMode:
+    ACCESSIBLE_LOCATIONS: int = 0
+    GAME_BEATABLE: int = 1
+    ALL_LOCATIONS_REACHABLE: int = 2
+    GENERATE_PLAYTHROUGH: int = 3
+    SPHERE_ZERO: int = 4
+    TRACKER_SPHERES: int = 5
+    LOCATION_IMPORTANCE: int = 6

--- a/logic/tooltips/tooltips.py
+++ b/logic/tooltips/tooltips.py
@@ -443,3 +443,17 @@ def pretty_name(item, count):
         return f"{item} x {count}"
     else:
         return item
+
+
+def flatten_world_requirements(world: World) -> None:
+
+    # Run the tooltip search. This will set the simplified
+    # requirement for each location
+    flatten = TooltipsSearch(world)
+    flatten.do_search()
+
+    # For each location, get the items which appear in its simplified access expression
+    for loc in world.get_all_item_locations():
+        # For each item, add this location as a chain location for that item
+        for item in loc.computed_requirement.get_items(world):
+            item.chain_locations.add(loc)

--- a/logic/world.py
+++ b/logic/world.py
@@ -116,6 +116,7 @@ class World:
                 shop_model_name = item_node.get("shop_model_name", None)
                 major_item = item_node.get("advancement", False)
                 game_winning_item = item_node.get("game_winning_item", False)
+                goddess_chest = item_node.get("goddess_chest", None)
 
                 stripped_name = name.replace("'", "")
                 self.item_table[stripped_name] = Item(
@@ -127,6 +128,7 @@ class World:
                     self,
                     major_item,
                     game_winning_item,
+                    goddess_chest,
                 )
                 logging.getLogger("").debug(
                     f"Processing new item {name}\tid: {item_id}"

--- a/logic/world.py
+++ b/logic/world.py
@@ -71,8 +71,8 @@ class World:
         self.plandomizer_entrances: dict[Entrance, Entrance] = {}
 
         # Hint related things
-        # path_locations maps a goal location to its set of path locations
-        self.path_locations: dict[Location, list[Location]] = {}
+        # goal_locations are locations at the end of required dungeons and Defeat Demise
+        self.goal_locations: list[Location] = []
         # barren_regions maps a hint region to the list of all locations in the region
         self.barren_regions: OrderedDict[str, list[Location]] = OrderedDict()
         self.fi_hints: list[Location] = []
@@ -116,7 +116,6 @@ class World:
                 shop_model_name = item_node.get("shop_model_name", None)
                 major_item = item_node.get("advancement", False)
                 game_winning_item = item_node.get("game_winning_item", False)
-                chain_locations = item_node.get("chain_locations", [])
 
                 stripped_name = name.replace("'", "")
                 self.item_table[stripped_name] = Item(
@@ -128,7 +127,6 @@ class World:
                     self,
                     major_item,
                     game_winning_item,
-                    chain_locations,
                 )
                 logging.getLogger("").debug(
                     f"Processing new item {name}\tid: {item_id}"

--- a/patches/checkpatchhandler.py
+++ b/patches/checkpatchhandler.py
@@ -156,8 +156,7 @@ def determine_check_patches(
                                         [
                                             loc
                                             for loc in item.chain_locations
-                                            if loc in location_table
-                                            and location_table[loc].progression
+                                            if loc.progression
                                         ]
                                     )
                                     > 0


### PR DESCRIPTION
## What does this address?

This PR implements Hint Importance and builds off of ideas in #419 . However my idea for implementation was different, so I felt that it would make more sense to open a new PR instead of backpacking off of the old one.

Hint Importance will label each progression location as `required` (path to Demise), `possibly required` (can be used to unlock progression but is not strictly required), or `not required` (does not help unlock progression in any way). When a location which has an item that can potentially unlock progression checks is hinted, the hint text will also say whether or not the item at the location is `required`, `possibly required`, or `not required`.

Hint Importance is also a setting in SDR. Unlike SDR though, this implementation takes into account where an item is placed in the world to determine its importance. Calculating if a major item is `required` is easy, that's just an item on the path to demise. Calculating if a major item is `possibly required` or `not required` can be much more challenging for certain cases (e.g. Progressive Beetle). This implementation should correctly identify almost all cases of importance. There are a few select cases that can result in items which are `not required` being labeled as `possibly required`, but this should be exceptionally rare and will only ever give misinformation in this one direction.

## How did/do you test these changes?

I generated dozens of seeds and manually verified the importance of `possibly required` and `not required` locations.
