### PR TITLE
Change tests to allow for running in parallel

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -63,7 +63,17 @@ Add your `romfs` and `exefs` to `./sshd_extract`.
 
 You won't be able to test randomization without it, so you'll need it during development as well. Our `.gitignore` will prevent you from accidentally committing those files, so it's safe to put there.
 
-#### 4. Run
+#### 4. Tests
+
+```sh
+# Run tests one after another
+pytest
+
+# Run tests in parallel
+pytest -n auto
+```
+
+#### 5. Run
 
 ```sh
 py ./sshdrando.py

--- a/logic/world.py
+++ b/logic/world.py
@@ -314,9 +314,17 @@ class World:
             self.setting("required_dungeons") == "7"
             and self.setting("dungeons_include_sky_keep") == "off"
         ):
-            raise ValueError(
-                "Cannot require 7 dungeons when Sky Keep is not a dungeon. Please either reduce the required dungeon count or enable Sky Keep to be a required dungeon."
-            )
+            # If dungeons_include_sky_keep is being chosen randomly, then we'll set it to on to fix the issue
+            if self.setting("dungeons_include_sky_keep").setting.is_using_random_option:
+                self.setting("dungeons_include_sky_keep").set_value("on")
+            # Otherwise if required_dungeons is random, set it back down to 6
+            elif self.setting("required_dungeons").setting.is_using_random_option:
+                self.setting("required_dungeons").set_value("6")
+            # If neither are random, then it's the user's fault
+            else:
+                raise ValueError(
+                    "Cannot require 7 dungeons when Sky Keep is not a dungeon. Please either reduce the required dungeon count or enable Sky Keep to be a required dungeon."
+                )
 
     def place_hardcoded_items(self) -> None:
         defeat_demise = self.get_location("Hylia's Realm - Defeat Demise")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pyclip~=0.7.0
 # dev stuff
 black~=25.1.0
 pytest~=8.3.1
+pytest-xdist~=3.6.1
 PyInstaller~=6.12.0
 Pillow~=11.1.0
 appdirs~=1.4.4

--- a/tests/test_configs/all_hints.yaml
+++ b/tests/test_configs/all_hints.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: KeyFiendDodohFiend
 World 1:
   path_hints: '7'
   path_hints_on_fi: 'on'

--- a/tests/test_configs/beatable_only.yaml
+++ b/tests/test_configs/beatable_only.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: FireflyTytoErlaDoor
 World 1:
   logic_rules: beatable_only

--- a/tests/test_configs/decouple_entrances.yaml
+++ b/tests/test_configs/decouple_entrances.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTESTTEST
+seed: SandKeepRicketyDive
 World 1:
   randomize_dungeon_entrances: "on"
   randomize_door_entrances: "on"

--- a/tests/test_configs/default_multiworld_config.yaml
+++ b/tests/test_configs/default_multiworld_config.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: BalladPouchBugArachnid
 World 1:
   setting: default_value # Dummy field to make World 1 a map
 World 2:

--- a/tests/test_configs/dungeon_items_any_dungeon.yaml
+++ b/tests/test_configs/dungeon_items_any_dungeon.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: PeaterPlumeKeeseQuiver
 World 1:
   boss_keys: any_dungeon
   map_mode: any_dungeon

--- a/tests/test_configs/dungeon_items_anywhere.yaml
+++ b/tests/test_configs/dungeon_items_anywhere.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: KyteSilvaLongswordEruption
 World 1:
   boss_keys: anywhere
   lanayru_caves_keys: anywhere

--- a/tests/test_configs/dungeon_items_overworld.yaml
+++ b/tests/test_configs/dungeon_items_overworld.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: ParrowTentalusFiPotion
 World 1:
   boss_keys: overworld
   lanayru_caves_keys: overworld

--- a/tests/test_configs/dungeon_items_own_dungeon.yaml
+++ b/tests/test_configs/dungeon_items_own_dungeon.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: GuardianLoftwingHeartDusk
 World 1:
   boss_keys: own_dungeon
   map_mode: own_dungeon_restricted

--- a/tests/test_configs/dungeon_items_own_region.yaml
+++ b/tests/test_configs/dungeon_items_own_region.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: SummitArmosBeedleEagus
 World 1:
   boss_keys: own_region
   map_mode: own_region

--- a/tests/test_configs/dungeon_items_removed.yaml
+++ b/tests/test_configs/dungeon_items_removed.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: PouchFruitArrowFirefly
 World 1:
   boss_keys: removed
   lanayru_caves_keys: removed

--- a/tests/test_configs/dungeon_items_vanilla.yaml
+++ b/tests/test_configs/dungeon_items_vanilla.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: PropellerRockKyteGorko
 World 1:
   boss_keys: vanilla
   lanayru_caves_keys: vanilla

--- a/tests/test_configs/fi_hints.yaml
+++ b/tests/test_configs/fi_hints.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: ParellaStaldraMonsterOre
 World 1:
   path_hints: '7'
   path_hints_on_fi: 'on'

--- a/tests/test_configs/gossip_stone_hints.yaml
+++ b/tests/test_configs/gossip_stone_hints.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: StarryGrebaHornHook
 World 1:
   path_hints: "7"
   barren_hints: "7"

--- a/tests/test_configs/impa_sot_hint.yaml
+++ b/tests/test_configs/impa_sot_hint.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: FortuneKnightFlowerLake
 World 1:
   impa_hint: "on"

--- a/tests/test_configs/item_pool_extra.yaml
+++ b/tests/test_configs/item_pool_extra.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: HighLeddInsectThunderhead
 World 1:
   item_pool: extra

--- a/tests/test_configs/item_pool_minimal.yaml
+++ b/tests/test_configs/item_pool_minimal.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: GrebaTornadoCourageSwirrell
 World 1:
   item_pool: minimal

--- a/tests/test_configs/item_pool_plentiful.yaml
+++ b/tests/test_configs/item_pool_plentiful.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: TowerBeamosDreadfuseAracha
 World 1:
   item_pool: plentiful

--- a/tests/test_configs/max_entrance_rando.yaml
+++ b/tests/test_configs/max_entrance_rando.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: CraniocMachiTrueDigging
 World 1:
   random_starting_spawn: anywhere
   randomize_dungeon_entrances: "on"

--- a/tests/test_configs/minigames_easy.yaml
+++ b/tests/test_configs/minigames_easy.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: HeadmasterFairyFruitHarbour
 World 1:
   minigame_difficulty: easy
   excluded_locations:

--- a/tests/test_configs/minigames_guaranteed_win.yaml
+++ b/tests/test_configs/minigames_guaranteed_win.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: GearBazaarMoblinMerco
 World 1:
   minigame_difficulty: guaranteed_win
   excluded_locations:

--- a/tests/test_configs/minigames_hard.yaml
+++ b/tests/test_configs/minigames_hard.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: ChuchuAutomatonVolcanoSand
 World 1:
   minigame_difficulty: hard
   excluded_locations:

--- a/tests/test_configs/minigames_vanilla.yaml
+++ b/tests/test_configs/minigames_vanilla.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: BehindTearGorgeThrill
 World 1:
   minigame_difficulty: vanilla
   excluded_locations:

--- a/tests/test_configs/mixed_pools.yaml
+++ b/tests/test_configs/mixed_pools.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: GosellePouchDiveBlob
 World 1:
   randomize_dungeon_entrances: "on"
   randomize_trial_gate_entrances: "on"

--- a/tests/test_configs/no_logic.yaml
+++ b/tests/test_configs/no_logic.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: SummitTurfHallRound
 World 1:
   logic_rules: no_logic

--- a/tests/test_configs/random_closets.yaml
+++ b/tests/test_configs/random_closets.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: InsectStaldraSkullDetected
 World 1:
   npc_closet_shuffle: randomized

--- a/tests/test_configs/random_crystals.yaml
+++ b/tests/test_configs/random_crystals.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: LeviasSkytailBeamosPyroclastic
 World 1:
   gratitude_crystal_shuffle: "on"

--- a/tests/test_configs/random_shops.yaml
+++ b/tests/test_configs/random_shops.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: FacilityNayruEarthFledge
 World 1:
   beedle_shop_shuffle: randomized

--- a/tests/test_configs/random_stamina_fruit.yaml
+++ b/tests/test_configs/random_stamina_fruit.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: TriforceGreatPiperSilent
 World 1:
   stamina_fruit_shuffle: "on"

--- a/tests/test_configs/random_starting_spawn_any_surface_region.yaml
+++ b/tests/test_configs/random_starting_spawn_any_surface_region.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: SanctuaryLumpySailclothPhoeni
 World 1:
   random_starting_spawn: any_surface_region

--- a/tests/test_configs/random_starting_spawn_anywhere.yaml
+++ b/tests/test_configs/random_starting_spawn_anywhere.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: GoldenPieceRevitalizingHouse
 World 1:
   random_starting_spawn: anywhere

--- a/tests/test_configs/random_starting_spawn_bird_statues.yaml
+++ b/tests/test_configs/random_starting_spawn_bird_statues.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: LizalfosAbyssalSilvaPeater
 World 1:
   random_starting_spawn: bird_statues

--- a/tests/test_configs/random_starting_statues.yaml
+++ b/tests/test_configs/random_starting_statues.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: SwirrellLifeGroosenatorPlume
 World 1:
   random_starting_statues: "on"

--- a/tests/test_configs/random_tadtones.yaml
+++ b/tests/test_configs/random_tadtones.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: AcademyNetImpaKikwi
 World 1:
   tadtone_shuffle: 'on'

--- a/tests/test_configs/randomize_door_entrances.yaml
+++ b/tests/test_configs/randomize_door_entrances.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: SheikahRockArachnidTough
 World 1:
   randomize_door_entrances: "on"

--- a/tests/test_configs/randomize_door_entrances_decoupled.yaml
+++ b/tests/test_configs/randomize_door_entrances_decoupled.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: AdventureAuraLuvBokoblin
 World 1:
   randomize_door_entrances: "on"
   decouple_double_doors: "on"

--- a/tests/test_configs/randomize_dungeon_entrances.yaml
+++ b/tests/test_configs/randomize_dungeon_entrances.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: DeepPartyBirdViewing
 World 1:
   randomize_dungeon_entrances: "on"

--- a/tests/test_configs/randomize_interior_entrances.yaml
+++ b/tests/test_configs/randomize_interior_entrances.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: SpeciesQuadroBottleDive
 World 1:
   randomize_interior_entrances: "on"

--- a/tests/test_configs/randomize_overworld_entrances.yaml
+++ b/tests/test_configs/randomize_overworld_entrances.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: TabletLadybugMercoLink
 World 1:
   randomize_overworld_entrances: "on"

--- a/tests/test_configs/randomize_trial_gate_entrances.yaml
+++ b/tests/test_configs/randomize_trial_gate_entrances.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: HarpGondoFledgeAncient
 World 1:
   randomize_trial_gate_entrances: "on"

--- a/tests/test_configs/rupee_shuffle_advanced.yaml
+++ b/tests/test_configs/rupee_shuffle_advanced.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: LeddStalmasterGroosenatorRound
 World 1:
   rupee_shuffle: advanced
   underground_rupee_shuffle: "on"

--- a/tests/test_configs/rupee_shuffle_beginner.yaml
+++ b/tests/test_configs/rupee_shuffle_beginner.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: StaldraFairyGuayOrnamental
 World 1:
   rupee_shuffle: beginner
   underground_rupee_shuffle: "off"

--- a/tests/test_configs/rupee_shuffle_intermediate.yaml
+++ b/tests/test_configs/rupee_shuffle_intermediate.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: GraveyardBowLanayruLumpy
 World 1:
   rupee_shuffle: intermediate
   underground_rupee_shuffle: "off"

--- a/tests/test_configs/rupee_shuffle_off.yaml
+++ b/tests/test_configs/rupee_shuffle_off.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: ItemBeaconClawBucha
 World 1:
   rupee_shuffle: vanilla
   underground_rupee_shuffle: "off"

--- a/tests/test_configs/song_hints_advanced.yaml
+++ b/tests/test_configs/song_hints_advanced.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: ArachaBokoblinLizalfosShield
 World 1:
   song_hints: advanced

--- a/tests/test_configs/song_hints_basic.yaml
+++ b/tests/test_configs/song_hints_basic.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: SilvaDodohCicadaAirshop
 World 1:
   song_hints: basic

--- a/tests/test_configs/spoiler_as_config.yaml
+++ b/tests/test_configs/spoiler_as_config.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTESTTEST
+seed: LopsaSpringKikwiOrnamental
 World 1:
   logic_rules: all_locations_reachable
   # Can't be random as "minimal" causes 4 locations to be unreachable

--- a/tests/test_configs/starting_inventory_bad.yaml
+++ b/tests/test_configs/starting_inventory_bad.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: MogmaTabletEruptionStaldra
 World 1:
   starting_sword: no_sword
   starting_inventory:

--- a/tests/test_configs/starting_inventory_good.yaml
+++ b/tests/test_configs/starting_inventory_good.yaml
@@ -1,3 +1,3 @@
-seed: TESTTESTTEST
+seed: SacredBertieDuskDemon
 World 1:
   starting_sword: goddess_sword

--- a/tests/test_configs/traps_all.yaml
+++ b/tests/test_configs/traps_all.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: LopsaPhoeniPlatformQuiver
 World 1:
   trap_mode: traptacular
   trappable_items: any_items

--- a/tests/test_configs/traps_off.yaml
+++ b/tests/test_configs/traps_off.yaml
@@ -1,4 +1,4 @@
-seed: TESTTESTTEST
+seed: FurnixDetectedDetectedMogma
 World 1:
   trap_mode: no_traps
   trappable_items: major_items

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -83,10 +83,6 @@ def test_default_undefined_config() -> None:
     return
 
 
-def test_default_config() -> None:
-    config_test("default_empty_config.yaml")
-
-
 def test_max_entrance_rando() -> None:
     config_test("max_entrance_rando.yaml")
 


### PR DESCRIPTION
## What does this address?

This changes each test config to have their own seed so that they can run in parallel using the `pytest-xdist` plugin. This significantly reduces the time it takes to run tests locally. Different seeds were necessary since sometimes different tests would generate the same hash and then run into issues trying to remove the same spoiler log file simultaneously.

Also fixes the issue of when `required_dungeons` sets to `7` when random and `dungeons_include_sky_keep` sets to `off` when random simultaneously.

## How did/do you test these changes?

I ran `pytest` using as many cores as I could multiple times and all tests passed each time.

## Notes

I didn't include the plugin in the github actions workflow since I figure it probably doesn't matter a whole lot there.
