### PR TITLE
Fix Dreadfuse chest to logically require beating Dreadfuse

### DIFF
--- a/data/world/Sky Keep.yaml
+++ b/data/world/Sky Keep.yaml
@@ -20,7 +20,9 @@
     SK Earth Temple Room North: can_access(SK Fire Sanctuary Room East)
     SK Earth Temple Room East: can_access(SK Fire Sanctuary Room East)
     SK Dreadfuse Room South: can_access(SK Fire Sanctuary Room East)
-    SK Dreadfuse Room West: can_access(SK Fire Sanctuary Room East)
+    # There are bars blocking the way to the chest until Dreadfuse is dead
+    # so while you can get here without beating Dreadfuse, doing so is useless
+    # SK Dreadfuse Room West: can_access(SK Fire Sanctuary Room East)
     SK Ancient Cistern Room South: can_access(SK Skyview Room North)
     SK Ancient Cistern Room East: can_access(SK LMF Room North)
     SK Fire Sanctuary Room East: can_access(SK LMF Room North)
@@ -76,11 +78,14 @@
   dungeon: Sky Keep
   exits:
     SK Dreadfuse Room West: Can_Defeat_Scervo_And_Dreadfuse and Clawshots
-  locations:
-    Sky Keep - Chest after Dreadfuse Fight: Nothing
 
 
 - name: SK Dreadfuse Room West
+  dungeon: Sky Keep
+  exits:
+    SK Dreadfuse Room South: can_access(SK Dreadfuse Room South) and Can_Defeat_Scervo_And_Dreadfuse and Clawshots
+  locations:
+    Sky Keep - Chest after Dreadfuse Fight: Nothing
 
 
 - name: SK Ancient Cistern Room South


### PR DESCRIPTION
## What does this address?

Fixes the logic for the Dreadfuse chest in Sky Keep.


## How did/do you test these changes?

I started a new tracker and the tooltip shows the check now needs a sword and the ability to buy a shield.