### PR TITLE
Item Pool Tweaks

### DIFF
--- a/constants/itemconstants.py
+++ b/constants/itemconstants.py
@@ -112,6 +112,35 @@ ITEMS_NOT_TO_TRAP = (
 )
 
 # Item Pools
+SHUFFLE_DEPENDENT_ITEMS: list[str] = (
+    [
+        GREEN_RUPEE,
+        BLUE_RUPEE,
+        RED_RUPEE,
+        SILVER_RUPEE,
+        GOLD_RUPEE,
+        RUPOOR,
+        FIVE_DEKU_SEEDS,
+        TEN_DEKU_SEEDS,
+        SINGLE_ARROW,
+        TEN_ARROWS,
+        FIVE_BOMBS,
+        TEN_BOMBS,
+        COMMON_TREASURE,
+        UNCOMMON_TREASURE,
+        RARE_TREASURE,
+        # COMMON_BUG,
+        # UNCOMMON_BUG,
+        # RARE_BUG,
+    ]
+    + list(COMMON_TREASURES)
+    + list(UNCOMMON_TREASURES)
+    + list(RARE_TREASURES)
+    # + list(COMMON_BUGS)
+    # + list(UNCOMMON_BUGS)
+    # + list(RARE_BUGS)
+)
+
 ALL_JUNK_ITEMS: list[str] = (
     [
         # HEART,
@@ -217,17 +246,6 @@ MINIMAL_ITEM_POOL: list[str] = (
     + [HEART_PIECE] * 24
     + [HEART_CONTAINER] * 6
     + [LIFE_MEDAL] * 2
-    + [GREEN_RUPEE] * 3
-    + [BLUE_RUPEE] * 11
-    + [RED_RUPEE] * 42
-    + [SILVER_RUPEE] * 22
-    + [GOLD_RUPEE] * 11
-    + [UNCOMMON_TREASURE] * 10
-    + [GOLDEN_SKULL] * 1
-    + [RARE_TREASURE] * 12
-    + [EVIL_CRYSTAL] * 2
-    + [ELDIN_ORE] * 2
-    + [RUPOOR] * 5
     + [
         SV_MAP,
         ET_MAP,

--- a/data/presets/Beginner.yaml
+++ b/data/presets/Beginner.yaml
@@ -43,6 +43,7 @@ World 1:
   impa_sot_hint: 'on'
   cryptic_hint_text: 'off'
   always_hints: 'on'
+  hint_importance: 'off'
   random_starting_statues: 'off'
   random_starting_spawn: vanilla
   limit_starting_spawn: 'off'

--- a/data/presets/Chestless.yaml
+++ b/data/presets/Chestless.yaml
@@ -43,6 +43,7 @@ World 1:
   impa_sot_hint: 'on'
   cryptic_hint_text: 'off'
   always_hints: 'on'
+  hint_importance: 'off'
   random_starting_statues: 'off'
   random_starting_spawn: vanilla
   limit_starting_spawn: 'off'

--- a/data/presets/Max Settings.yaml
+++ b/data/presets/Max Settings.yaml
@@ -43,6 +43,7 @@ World 1:
   impa_sot_hint: 'on'
   cryptic_hint_text: 'off'
   always_hints: 'on'
+  hint_importance: 'off'
   random_starting_statues: 'off'
   random_starting_spawn: vanilla
   limit_starting_spawn: 'off'

--- a/logic/location_table.py
+++ b/logic/location_table.py
@@ -73,7 +73,7 @@ def get_disabled_shuffle_locations(
 ) -> list[Location]:
     settings = settings_map.settings
 
-    non_vanilla_locations = [
+    disabled_locations = [
         location
         for location in location_table.values()
         if location.types is not None
@@ -145,4 +145,4 @@ def get_disabled_shuffle_locations(
         )
     ]
 
-    return non_vanilla_locations
+    return disabled_locations

--- a/sshdrando.py
+++ b/sshdrando.py
@@ -15,7 +15,7 @@ import logging
 args = get_program_args()
 
 # Set specified log level
-if args.debug and __name__ == "__main__":
+if args.debug:
     print("Starting Debug Log")
     logging.basicConfig(
         filename="debug.log",

--- a/sshdrando_nogui.py
+++ b/sshdrando_nogui.py
@@ -1,3 +1,9 @@
 import os
+from util.arguments import get_program_args
 
-os.system("sshdrando.py --nogui ")
+args = get_program_args()
+
+if args.debug:
+    os.system("sshdrando.py --nogui --debug")
+else:
+    os.system("sshdrando.py --nogui ")


### PR DESCRIPTION
## What does this address?

Makes the item pool change depending on the enabled shuffles. Takes the `original_item` field for each location and, for each rupees, treasure, or ammo, adds it to the item pool. If a location contains a type which is disabled (e.g. locations with the "Hidden Item" type while `hidden_item_shuffle` is turned off), then those items are ignored.

This makes the item pool better reflect the vanilla item pool, rather than picking uniformly from the `ALL_JUNK_ITEMS` list. Basically means that, with rupee shuffle or hidden item shuffle enabled, the game has lots more green and blue rupees compared to red rupees, rupoors, and ammos. This also means that when goddess_chest_shuffle is turned off there will be fewer gold rupees in the item pool.

Also fixes a niche bug with the item pool when generating multiple seeds without closing the randomizer program, updates the presets, and allows `python sshdrando_nogui.py --debug` to actually output the debug.log file.


## How did/do you test these changes?

I made use of (now commented out) print statements to verify that the item pool changed as expected and verified this with the spoiler logs. I tested various seeds with different shuffles enabled and disabled.