### PR TITLE
Take minigame difficulty into account for one and done items

### DIFF
--- a/logic/hints.py
+++ b/logic/hints.py
@@ -82,7 +82,6 @@ def sanitize_major_items(worlds: list[World]) -> None:
     # then the rest of that item are not major items
     one_then_junk_items = [
         PROGRESSIVE_BOW,
-        PROGRESSIVE_BUG_NET,
         PROGRESSIVE_SLINGSHOT,
         PROGRESSIVE_POUCH,
         EMPTY_BOTTLE,
@@ -98,11 +97,17 @@ def sanitize_major_items(worlds: list[World]) -> None:
     }
 
     for world in worlds:
+
+        world_one_then_junk = one_then_junk_items.copy()
+        # Only add bug net if minigame difficulty is vaniulla, or hard
+        if world.setting("minigame_difficulty").is_any_of("vanilla", "hard"):
+            world_one_then_junk.append(PROGRESSIVE_BUG_NET)
+
         for location in world.get_all_item_locations():
             item = location.current_item
             if (
                 (
-                    item.name in one_then_junk_items
+                    item.name in world_one_then_junk
                     and world.starting_item_pool[item] > 0
                 )
                 or (


### PR DESCRIPTION
## What does this address?

Some usually major items are changed to be non-major items for hint purposes if we start with one of those items in the inventory (bow, slingshot, etc.). Bug net was included in this, but due to Big Bug Net being logically required for easy or guaranteed win, it has to be added depending on the `minigame_difficulty` setting.

## How did/do you test these changes?

I generated seeds with `minigame_difficulty` set to easy and vanilla. When set to vanilla the debug log confirmed that the 2nd progressive bug net was not major if I started with one already, but didn't do this when `minigame_difficulty` was set to easy.
