### PR TITLE
Fix logic error when starting at Pirate Stronghold Top Door from Inside the Shark Head

### DIFF
--- a/data/world/Lanayru.yaml
+++ b/data/world/Lanayru.yaml
@@ -579,7 +579,7 @@
 - name: Pirate Stronghold Top Door
   exits:
     Pirate Stronghold Interior: Nothing
-    Pirate Stronghold Inside the Shark Head: Nothing
+    Pirate Stronghold Inside the Shark Head: "'Finish_Pirate_Stronghold'"
 
 # Lanayru Statues
 - name: Lanayru Mine Entry Statue


### PR DESCRIPTION
## What does this address?

This fixes the logic error where starting at `Pirate Stronghold Top Door from Pirate Stronghold Inside the Shark Head` which assumed players could exit out to `Pirate Stronghold Inside the Shark Head` without first finishing the inside portion of Pirate Stronghold.

## How did/do you test these changes?

I generated a seed with the Triforce of Courage plando'd onto `Central Skyloft - Goddess Chest on Waterfall Island` and set the spawn to `Pirate Stronghold Top Door from Pirate Stronghold Inside the Shark Head`. The playthrough required Gust Bellows to be obtained before the Triforce of Courage could be obtained.
