### PR TITLE
Update presets

### DIFF
--- a/data/presets/Beginner.yaml
+++ b/data/presets/Beginner.yaml
@@ -135,6 +135,7 @@ World 1:
   logic_bomb_throws: 'off'
   logic_faron_woods_with_groosenator: 'off'
   logic_itemless_first_timeshift_stone: 'off'
+  logic_stamina_potion_through_sink_sand: 'off'
   logic_brakeslide: 'off'
   logic_lanayru_mine_quick_bomb: 'off'
   logic_tot_skip_brakeslide: 'off'

--- a/data/presets/Chestless.yaml
+++ b/data/presets/Chestless.yaml
@@ -135,6 +135,7 @@ World 1:
   logic_bomb_throws: 'off'
   logic_faron_woods_with_groosenator: 'off'
   logic_itemless_first_timeshift_stone: 'off'
+  logic_stamina_potion_through_sink_sand: 'off'
   logic_brakeslide: 'off'
   logic_lanayru_mine_quick_bomb: 'off'
   logic_tot_skip_brakeslide: 'off'

--- a/data/presets/Max Settings.yaml
+++ b/data/presets/Max Settings.yaml
@@ -14,8 +14,8 @@ World 1:
   underground_rupee_shuffle: 'on'
   beedle_shop_shuffle: randomized
   goddess_chest_shuffle: 'on'
-  trial_treasure_shuffle: '0'
-  tadtone_shuffle: 'off'
+  trial_treasure_shuffle: '10'
+  tadtone_shuffle: 'on'
   full_wallet_upgrades: 'off'
   skip_harp_playing: 'off'
   random_trial_object_positions: none
@@ -135,6 +135,7 @@ World 1:
   logic_bomb_throws: 'off'
   logic_faron_woods_with_groosenator: 'off'
   logic_itemless_first_timeshift_stone: 'off'
+  logic_stamina_potion_through_sink_sand: 'off'
   logic_brakeslide: 'off'
   logic_lanayru_mine_quick_bomb: 'off'
   logic_tot_skip_brakeslide: 'off'


### PR DESCRIPTION
## What does this address?

Updates the default presets to include the new `logic_stamina_potion_through_sink_sand` trick. Also enables `tadtone_shuffle` and `trial_treasure_shuffle` for the Max Settings preset