### PR TITLE
Add shortcut settings for the Sky Keep FS room

### DIFF
--- a/data/patches/startflags.yaml
+++ b/data/patches/startflags.yaml
@@ -358,7 +358,11 @@ Sceneflags:
     - small_keys == removed:
       - 63 # Unlocked key locked door
     - shortcut_sky_keep_svt_room_bars == on:
-      - 70 # Bars in Skyview room raised
+      - 70 # Bars in Skyview Temple room raised
+    - shortcut_sky_keep_fs_room_lower_bars == on:
+      - 40 # Lower bars in Fire Sanctuary room raised
+    - shortcut_sky_keep_fs_room_upper_bars == on:
+      - 42 # Upper bars in Fire Sanctuary room raised
 
   The Sky: # Scene Index 21
     - shortcut_ios_bridge_complete == on:

--- a/data/presets/Beginner.yaml
+++ b/data/presets/Beginner.yaml
@@ -120,6 +120,8 @@ World 1:
   shortcut_fs_outside_bars: 'off'
   shortcut_fs_lava_flow: 'on'
   shortcut_sky_keep_svt_room_bars: 'on'
+  shortcut_sky_keep_fs_room_lower_bars: 'on'
+  shortcut_sky_keep_fs_room_upper_bars: 'off'
   logic_early_lake_floria: 'off'
   logic_beedles_island_cage_chest_dive: 'off'
   logic_volcanic_island_dive: 'off'

--- a/data/presets/Chestless.yaml
+++ b/data/presets/Chestless.yaml
@@ -120,6 +120,8 @@ World 1:
   shortcut_fs_outside_bars: 'off'
   shortcut_fs_lava_flow: 'on'
   shortcut_sky_keep_svt_room_bars: 'on'
+  shortcut_sky_keep_fs_room_lower_bars: 'on'
+  shortcut_sky_keep_fs_room_upper_bars: 'off'
   logic_early_lake_floria: 'off'
   logic_beedles_island_cage_chest_dive: 'off'
   logic_volcanic_island_dive: 'off'

--- a/data/presets/Max Settings.yaml
+++ b/data/presets/Max Settings.yaml
@@ -120,6 +120,8 @@ World 1:
   shortcut_fs_outside_bars: 'off'
   shortcut_fs_lava_flow: 'on'
   shortcut_sky_keep_svt_room_bars: 'on'
+  shortcut_sky_keep_fs_room_lower_bars: 'on'
+  shortcut_sky_keep_fs_room_upper_bars: 'off'
   logic_early_lake_floria: 'off'
   logic_beedles_island_cage_chest_dive: 'off'
   logic_volcanic_island_dive: 'off'

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -1441,6 +1441,28 @@
     - "off": "You will need to traverse the Skyview Temple room in Sky Keep using most items in the item wheel to continue through Sky Keep."
     - "on": "The bars in the Skyview Temple room in Sky Keep will already be raised allowing you to skip traversing the room."
 
+- name: shortcut_sky_keep_fs_room_lower_bars
+  tracker_important: true
+  default_option: "on"
+  pretty_name: Sky Keep Lower Bars in Fire Sanctuary Room
+  pretty_options:
+    - "Off"
+    - "On"
+  options:
+    - "off": "You will need to fully traverse the Fire Sanctuary room in Sky Keep by riding magma platforms and using the Beetle and Clawshots."
+    - "on": "The lower bars in the Fire Sanctuary room in Sky Keep will already be raised. This does not change logic and merely speeds up this room."
+
+- name: shortcut_sky_keep_fs_room_upper_bars
+  tracker_important: true
+  default_option: "off"
+  pretty_name: Sky Keep Upper Bars in Fire Sanctuary Room
+  pretty_options:
+    - "Off"
+    - "On"
+  options:
+    - "off": "You will need to fully traverse the Fire Sanctuary room in Sky Keep by riding magma platforms and using the Beetle and Clawshots."
+    - "on": "The upper bars in the Fire Sanctuary room in Sky Keep will already be raised. This completely skips riding the magma platforms as well as using the Beetle and Clawshots."
+
 #############################
 ## Logic settings (tricks) ##
 #############################

--- a/data/world/Sky Keep.yaml
+++ b/data/world/Sky Keep.yaml
@@ -118,7 +118,23 @@
 - name: SK Fire Sanctuary Room East
   dungeon: Sky Keep
   exits:
-    SK Fire Sanctuary Room End Platform: Clawshots and (Beetle or (logic_skykeep_vineclip and Bomb_Bag))
+    SK Fire Sanctuary Room South: Beetle
+    SK Fire Sanctuary Room North: Beetle and shortcut_sky_keep_fs_room_lower_bars
+    SK Fire Sanctuary Room End Platform: (Clawshots and (Beetle or (logic_skykeep_vineclip and Bomb_Bag))) or shortcut_sky_keep_fs_room_upper_bars
+  locations:
+    Sky Keep - Rupee in Fire Sanctuary Room in Alcove: Beetle
+
+
+- name: SK Fire Sanctuary Room South
+  dungeon: Sky Keep
+  exits:
+    SK Fire Sanctuary Room East: Beetle # ride the lava river and open the lower bars
+    SK Fire Sanctuary Room North: Beetle
+
+- name: SK Fire Sanctuary Room North
+  dungeon: Sky Keep
+  exits:
+    SK Fire Sanctuary Room End Platform: Beetle and Clawshots
   locations:
     Sky Keep - Rupee in Fire Sanctuary Room in Alcove: Beetle
 
@@ -127,8 +143,8 @@
   dungeon: Sky Keep
   exits:
     SK Sacred Power of Din Room: Practice_Sword
-    SK Fire Sanctuary Room West: Nothing
-    SK Fire Sanctuary Room East: Nothing
+    SK Fire Sanctuary Room West: Nothing # raise the end bars
+    SK Fire Sanctuary Room East: Nothing # raise the upper bars
     
 
 - name: SK Sacred Power of Din Room

--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -36,7 +36,7 @@
        <enum>QTabWidget::TabShape::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="getting_started_tab">
        <property name="sizePolicy">
@@ -1229,7 +1229,7 @@
             <widget class="QComboBox" name="setting_open_lmf"/>
            </item>
            <item>
-            <widget class="Line" name="line">
+            <widget class="Line" name="open_dungeons_line">
              <property name="orientation">
               <enum>Qt::Orientation::Horizontal</enum>
              </property>
@@ -1323,6 +1323,20 @@
             <widget class="RandoTriStateCheckBox" name="setting_shortcut_sky_keep_svt_room_bars">
              <property name="text">
               <string>Sky Keep Bars in Skyview Temple Room</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="RandoTriStateCheckBox" name="setting_shortcut_sky_keep_fs_room_lower_bars">
+             <property name="text">
+              <string>Sky Keep Lower Bars in Fire Sanctuary Room</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="RandoTriStateCheckBox" name="setting_shortcut_sky_keep_fs_room_upper_bars">
+             <property name="text">
+              <string>Sky Keep Upper Bars in Fire Sanctuary Room</string>
              </property>
             </widget>
            </item>
@@ -3886,8 +3900,8 @@ Practice Sword</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>310</width>
-                <height>342</height>
+                <width>98</width>
+                <height>28</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="other_mods_scroll_layout"/>
@@ -3939,7 +3953,7 @@ QPushButton {
             <item>
              <layout class="QVBoxLayout" name="dungeon_svt_layout">
               <property name="spacing">
-               <number>1</number>S
+               <number>1</number>
               </property>
               <property name="sizeConstraint">
                <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
@@ -4346,8 +4360,8 @@ QPushButton {
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>546</width>
-               <height>340</height>
+               <width>100</width>
+               <height>30</height>
               </rect>
              </property>
              <property name="maximumSize">

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -853,12 +853,12 @@ class Ui_main_window(object):
 
         self.verticalLayout_25.addWidget(self.setting_open_lmf)
 
-        self.line = QFrame(self.open_dungeons_group_box)
-        self.line.setObjectName(u"line")
-        self.line.setFrameShape(QFrame.Shape.HLine)
-        self.line.setFrameShadow(QFrame.Shadow.Sunken)
+        self.open_dungeons_line = QFrame(self.open_dungeons_group_box)
+        self.open_dungeons_line.setObjectName(u"open_dungeons_line")
+        self.open_dungeons_line.setFrameShape(QFrame.Shape.HLine)
+        self.open_dungeons_line.setFrameShadow(QFrame.Shadow.Sunken)
 
-        self.verticalLayout_25.addWidget(self.line)
+        self.verticalLayout_25.addWidget(self.open_dungeons_line)
 
         self.setting_shortcut_skyview_boards = RandoTriStateCheckBox(self.open_dungeons_group_box)
         self.setting_shortcut_skyview_boards.setObjectName(u"setting_shortcut_skyview_boards")
@@ -924,6 +924,16 @@ class Ui_main_window(object):
         self.setting_shortcut_sky_keep_svt_room_bars.setObjectName(u"setting_shortcut_sky_keep_svt_room_bars")
 
         self.verticalLayout_25.addWidget(self.setting_shortcut_sky_keep_svt_room_bars)
+
+        self.setting_shortcut_sky_keep_fs_room_lower_bars = RandoTriStateCheckBox(self.open_dungeons_group_box)
+        self.setting_shortcut_sky_keep_fs_room_lower_bars.setObjectName(u"setting_shortcut_sky_keep_fs_room_lower_bars")
+
+        self.verticalLayout_25.addWidget(self.setting_shortcut_sky_keep_fs_room_lower_bars)
+
+        self.setting_shortcut_sky_keep_fs_room_upper_bars = RandoTriStateCheckBox(self.open_dungeons_group_box)
+        self.setting_shortcut_sky_keep_fs_room_upper_bars.setObjectName(u"setting_shortcut_sky_keep_fs_room_upper_bars")
+
+        self.verticalLayout_25.addWidget(self.setting_shortcut_sky_keep_fs_room_upper_bars)
 
         self.shortcuts_vspacer = QSpacerItem(20, 148, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
@@ -2537,7 +2547,7 @@ class Ui_main_window(object):
         self.other_mods_scroll_area.setWidgetResizable(True)
         self.other_mods_scroll_widget = QWidget()
         self.other_mods_scroll_widget.setObjectName(u"other_mods_scroll_widget")
-        self.other_mods_scroll_widget.setGeometry(QRect(0, 0, 310, 342))
+        self.other_mods_scroll_widget.setGeometry(QRect(0, 0, 98, 28))
         self.other_mods_scroll_layout = QVBoxLayout(self.other_mods_scroll_widget)
         self.other_mods_scroll_layout.setObjectName(u"other_mods_scroll_layout")
         self.other_mods_scroll_area.setWidget(self.other_mods_scroll_widget)
@@ -2875,7 +2885,7 @@ class Ui_main_window(object):
         self.tracker_locations_scroll_area.setWidgetResizable(True)
         self.tracker_locations_scroll_widget = QWidget()
         self.tracker_locations_scroll_widget.setObjectName(u"tracker_locations_scroll_widget")
-        self.tracker_locations_scroll_widget.setGeometry(QRect(0, 0, 546, 340))
+        self.tracker_locations_scroll_widget.setGeometry(QRect(0, 0, 100, 30))
         self.tracker_locations_scroll_widget.setMaximumSize(QSize(546, 16777215))
         self.tracker_locations_scroll_layout = QHBoxLayout(self.tracker_locations_scroll_widget)
         self.tracker_locations_scroll_layout.setSpacing(0)
@@ -3018,7 +3028,7 @@ class Ui_main_window(object):
 
         self.retranslateUi(main_window)
 
-        self.tab_widget.setCurrentIndex(0)
+        self.tab_widget.setCurrentIndex(2)
 
 
         QMetaObject.connectSlotsByName(main_window)
@@ -3128,6 +3138,8 @@ class Ui_main_window(object):
         self.setting_shortcut_fs_outside_bars.setText(QCoreApplication.translate("main_window", u"Fire Sanctuary Bars between Outdoor Bridges", None))
         self.setting_shortcut_fs_lava_flow.setText(QCoreApplication.translate("main_window", u"Fire Sanctuary Skip Lava Chase", None))
         self.setting_shortcut_sky_keep_svt_room_bars.setText(QCoreApplication.translate("main_window", u"Sky Keep Bars in Skyview Temple Room", None))
+        self.setting_shortcut_sky_keep_fs_room_lower_bars.setText(QCoreApplication.translate("main_window", u"Sky Keep Lower Bars in Fire Sanctuary Room", None))
+        self.setting_shortcut_sky_keep_fs_room_upper_bars.setText(QCoreApplication.translate("main_window", u"Sky Keep Upper Bars in Fire Sanctuary Room", None))
         self.entrance_randomization_group_box.setTitle(QCoreApplication.translate("main_window", u"Entrance Randomization", None))
         self.setting_randomize_door_entrances.setText(QCoreApplication.translate("main_window", u"Randomize Door Entrances", None))
         self.setting_randomize_interior_entrances.setText(QCoreApplication.translate("main_window", u"Randomize Interior Entrances", None))


### PR DESCRIPTION
## What does this address?

Adds two shortcuts to the Fire Sanctuary room in Sky Keep: one for the lower bars at the start (logically does nothing) and one for the upper bars at the start (skips beetle and clawshots).


## How did/do you test these changes?

* I tested generating a seed with each shortcut enabled individually, both off, and both on.
* I used the tracker to confirm that no logic changes are made when the lower bars start raised and that the beetle and clawshots requirements get removed when starting with the upper bars raised.
* I tested enabling each shortcut by itself and checking that the startflags worked and correctly raised the intended bars.


## Notes

I actually remembered to update the presets this time xD
