### PR TITLE
Add heart dowsing as a startflag

### DIFF
--- a/data/patches/startflags.yaml
+++ b/data/patches/startflags.yaml
@@ -12,6 +12,7 @@ Storyflags:
   - 81 # Tadtone Dowsing
   - 82 # Tadtones music scroll
   - 96 # Skip 1st time getting a map Fi text
+  - 108 # Heart Dowsing
   - 115 # Full Lake Floria map
   - 122 # Collected Deku Hornet for 1st time
   - 129 # Updated Lanayru Desert map


### PR DESCRIPTION
## What does this address?

Adds heart dowsing as a startflag (since you can't get it from talking to Fi with low health anymore).


## How did/do you test these changes?

I started a default settings seed, left academy and equipped the heart dowsing option.