### PR TITLE
Ignore .DS_Store on mac when stage patching

### DIFF
--- a/patches/stagepatchhandler.py
+++ b/patches/stagepatchhandler.py
@@ -1103,8 +1103,11 @@ class StagePatchHandler:
     def __extract_bzs_files(self, stage_file_paths):
         for current_stage_file_num, stage_path in enumerate(stage_file_paths):
             stage_name = stage_path.name
-            print_progress_text(f"Checking cached files for stage: {stage_name}")
+            # Ignore non-stage files
+            if stage_name not in BZS_FILE_HASHES:
+                continue
 
+            print_progress_text(f"Checking cached files for stage: {stage_name}")
             bzs_stage_dir_path = CACHE_BZS_PATH / stage_name
             bzs_stage_dir_path.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## What does this address?

When creating the bzs cache on mac, the glob for getting the filenames was picking up the hidden `.DS_Store` filename that's stored in every folder on a mac. Obviously this is not a stage file and was erroring out.

## How did/do you test these changes?

I was able to generate a seed on mac successfully.