### PR TITLE
Fix initializing tracker when trial treasure shuffle is random

### DIFF
--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -733,12 +733,21 @@ class Tracker:
         if self.world.setting("starting_sword") == "random":
             self.world.setting("starting_sword").set_value("no_sword")
 
+        # If trial treasure shuffle is random, set it to 10 for building the world, then back to random
+        trial_treasure_shuffle_is_random = False
+        if self.world.setting("trial_treasure_shuffle") == "random":
+            self.world.setting("trial_treasure_shuffle").set_value("10")
+            trial_treasure_shuffle_is_random = True
+
         # Build the world (only as necessary)
         self.world.build()
         self.world.perform_pre_entrance_shuffle_tasks()
 
         # Restore starting hearts value
         starting_hearts.set_value(starting_hearts_value)
+
+        if trial_treasure_shuffle_is_random:
+            self.world.setting("trial_treasure_shuffle").set_value("random")
 
         # Get any random settings. If any are passed in from the autosave
         # load those instead of loading them from the world

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -746,6 +746,7 @@ class Tracker:
         # Restore starting hearts value
         starting_hearts.set_value(starting_hearts_value)
 
+        # Restore trial treasure shuffle to random if it was before
         if trial_treasure_shuffle_is_random:
             self.world.setting("trial_treasure_shuffle").set_value("random")
 


### PR DESCRIPTION
## What does this address?

Fixes the tracker initializing to account for `trial treasure shuffle` being random.

## How did/do you test these changes?

I started a new tracker with `trial treasure shuffle` set to `random` and it works as expected.