### PR TITLE
Remove SotH as a starting item

### DIFF
--- a/data/macros.yaml
+++ b/data/macros.yaml
@@ -60,7 +60,7 @@ Can Afford 1200 Rupees: Can_High_Rupee_Farm and wallet_capacity(1200)
 
 Can Afford 1600 Rupees: Can_High_Rupee_Farm and wallet_capacity(1600)
 
-Full Song of the Hero: count(4, Song_of_the_Hero_Part) or Song_of_the_Hero # Starting Item
+Full Song of the Hero: count(4, Song_of_the_Hero_Part)
 
 Complete Triforce: Triforce_of_Courage and Triforce_of_Wisdom and Triforce_of_Power
 


### PR DESCRIPTION
## What does this address?

The logic for entering the Skyloft trial gate is: `Goddesss_Harp and Full_Song_of_the_Hero and Progressive_Sword`. The `Full_Song_of_the_Hero` macro included the 4 parts of the SotH as well as the complete SotH as used as a starting item. This removes the complete SotH as a starting item from the logic.


## How did/do you test these changes?

I tested the logic in the tracker, now only one `Song of the Hero` requirement appears. I tested starting with all 4 SotH parts, harp, and sword and was able to open the Skyloft trial gate (both with `skip_harp_playing` on and off)
