### PR TITLE
Fix stamina fruit logic near hot cave in Elidn

### DIFF
--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -134,6 +134,8 @@
     Thrill Digger Cave - Slingshot Right Pillar Blue Crystal 3: Slingshot
     Thrill Digger Cave - Slingshot Right Pillar Blue Crystal 4: Slingshot
 
+# Includes anything after the boko tower near Thrill Digger
+# and anything before the boko tower before hot cave
 - name: Near Temple Entrance
   hint_region: Eldin Volcano
   events:
@@ -167,9 +169,6 @@
     Eldin Volcano - Stamina Fruit below Slope before Temple 2: Nothing
     Eldin Volcano - Stamina Fruit below Slope before Temple 3: Nothing
     Eldin Volcano - Bonk Campfire East of Temple: Nothing
-    Eldin Volcano - Stamina Fruit after Last Boko Camp Tower: Nothing
-    Eldin Volcano - Stamina Fruit on Ledge near Hot Cave: Nothing
-    Eldin Volcano - Stamina Fruit on Vines near Hot Cave: Nothing
     Eldin Volcano - Gossip Stone on Cliff West of Temple: Digging_Mitts
     Eldin Volcano - Goddess Cube behind Bombable Rock West of Temple: Digging_Mitts and Goddess_Sword
     Eldin Volcano - Goddess Cube East of Temple: Goddess_Sword
@@ -187,12 +186,18 @@
   locations:
     Upper Eldin Cave - West Gossip Stone: Nothing
 
+# Includes anything after the boko tower
 - name: Hot Cave
   hint_region: Eldin Volcano
   exits:
     Volcano Summit: Fireshield_Earrings
     Sand Slide: Can_Survive_Hot_Cave
     Near Temple Entrance: can_access(Near Temple Entrance) or (logic_bomb_throws and Bomb_Bag)
+  locations:
+    # Activate the floor switch and run backwards
+    Eldin Volcano - Stamina Fruit after Last Boko Camp Tower: Nothing
+    Eldin Volcano - Stamina Fruit on Ledge near Hot Cave: Nothing
+    Eldin Volcano - Stamina Fruit on Vines near Hot Cave: Nothing
 
 - name: Sand Slide
   hint_region: Eldin Volcano


### PR DESCRIPTION
## What does this address?

Fixes the logic for the stamina fruits after the boko tower near the Earth Temple entrance.

The 3 stamina fruits were included in the main "Near Earth Temple" logical area which, when coming from the big air vent near hot cave, requires the bomb trick to enter thanks to the boko tower.

However, in-game, you can just press the floor switch and collect the 3 stamina fruits without having to climb the volcano past Thrill Digger. This PR moves these stamina fruit checks to the "Hot Cave" logical area.


## How did/do you test these changes?

I used the tracker to check the logic. Before the change, Ruby Tablet + Bomb Bag was insufficient to put the stamina fruits in logic (you were expected to climb up past Thrill Digger which requires Bow/Slingshot to get past the Bokoblin at the top of the sandy slope). After the change, the stamina fruits were in logic (as now you can use the bomb bag to open the way to the big air vent near Volcano Ascent and go backwards over the bridge).