### PR TITLE
Fix logic when natural_night_connections is turned off

### DIFF
--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -461,40 +461,40 @@
   events:
     Unlock Volcano Entrance Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Volcano Entrance: Nothing
 
 - name: Volcano East Statue
   events:
     Unlock Volcano East Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Volcano East: Nothing
 
 - name: Volcano Ascent Statue
   events:
     Unlock Volcano Ascent Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Volcano Ascent: Nothing
 
 - name: Temple Entrance Statue
   events:
     Unlock Temple Entrance Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Near Temple Entrance: Nothing
 
 - name: Inside the Volcano Statue
   events:
     Unlock Inside the Volcano Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Outside Fire Sanctuary: Nothing
 
 - name: Inside the Fire Sanctuary Statue
   events:
     Unlock Inside the Fire Sanctuary Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     FS In Front of Boss Door: Nothing

--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -461,40 +461,40 @@
   events:
     Unlock Volcano Entrance Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Volcano Entrance: Nothing
 
 - name: Volcano East Statue
   events:
     Unlock Volcano East Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Volcano East: Nothing
 
 - name: Volcano Ascent Statue
   events:
     Unlock Volcano Ascent Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Volcano Ascent: Nothing
 
 - name: Temple Entrance Statue
   events:
     Unlock Temple Entrance Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Near Temple Entrance: Nothing
 
 - name: Inside the Volcano Statue
   events:
     Unlock Inside the Volcano Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Outside Fire Sanctuary: Nothing
 
 - name: Inside the Fire Sanctuary Statue
   events:
     Unlock Inside the Fire Sanctuary Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     FS In Front of Boss Door: Nothing

--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -478,68 +478,68 @@
   events:
     Unlock Sealed Grounds Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Sealed Grounds: Nothing
 
 - name: Behind the Temple Statue
   events:
     Unlock Behind the Temple Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Behind the Temple: Nothing
 
 - name: Faron Woods Entry Statue
   events:
     Unlock Faron Woods Entry Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Faron Woods Entry: Nothing
 
 - name: Viewing Platform Statue
   events:
     Unlock Viewing Platform Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Faron Woods: Nothing
 
 - name: In the Woods Statue
   events:
     Unlock In the Woods Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Faron Woods: Nothing
 
 - name: Deep Woods Statue
   events:
     Unlock Deep Woods Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Deep Woods: Nothing
 
 - name: Forest Temple Statue
   events:
     Unlock Forest Temple Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Deep Woods: Nothing
 
 - name: The Great Tree Statue
   events:
     Unlock The Great Tree Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Great Tree Exterior Top: Nothing
 
 - name: Lake Floria Statue
   events:
     Unlock Lake Floria Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Lake Floria Emerged Area: Nothing
 
 - name: Floria Waterfall Statue
   events:
     Unlock Floria Waterfall Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Floria Waterfall: Nothing

--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -478,68 +478,68 @@
   events:
     Unlock Sealed Grounds Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Sealed Grounds: Nothing
 
 - name: Behind the Temple Statue
   events:
     Unlock Behind the Temple Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Behind the Temple: Nothing
 
 - name: Faron Woods Entry Statue
   events:
     Unlock Faron Woods Entry Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Faron Woods Entry: Nothing
 
 - name: Viewing Platform Statue
   events:
     Unlock Viewing Platform Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Faron Woods: Nothing
 
 - name: In the Woods Statue
   events:
     Unlock In the Woods Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Faron Woods: Nothing
 
 - name: Deep Woods Statue
   events:
     Unlock Deep Woods Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Deep Woods: Nothing
 
 - name: Forest Temple Statue
   events:
     Unlock Forest Temple Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Deep Woods: Nothing
 
 - name: The Great Tree Statue
   events:
     Unlock The Great Tree Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Great Tree Exterior Top: Nothing
 
 - name: Lake Floria Statue
   events:
     Unlock Lake Floria Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Lake Floria Emerged Area: Nothing
 
 - name: Floria Waterfall Statue
   events:
     Unlock Floria Waterfall Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Floria Waterfall: Nothing

--- a/data/world/Fire Sanctuary.yaml
+++ b/data/world/Fire Sanctuary.yaml
@@ -1,7 +1,3 @@
-# allowed_time_of_day: DayOnly
-# hint_region: Fire Sanctuary
-
-
 - name: Fire Sanctuary First Room
   dungeon: Fire Sanctuary
   dungeon_starting_area: true

--- a/data/world/Lanayru.yaml
+++ b/data/world/Lanayru.yaml
@@ -82,7 +82,7 @@
 - name: Lanayru Desert South
   hint_region: Lanayru Desert
   events:
-    Retrieve Party Wheel: Scrapper and 'Start_Dodohs_Quest' and Blow_Up_Covered_Timeshift_Stone
+    Retrieve Party Wheel: Scrapper and Blow_Up_Covered_Timeshift_Stone
     Ancient Flower Farming: Blow_Up_Covered_Timeshift_Stone
 
     # Hook Beetle to knock down statue platforms
@@ -587,82 +587,82 @@
   events:
     Unlock Lanayru Mine Entry Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Lanayru Mine Entry: Nothing
 
 - name: Desert Entrance Statue
   events:
     Unlock Desert Entrance Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Lanayru Desert South: Nothing
 
 - name: West Desert Statue
   events:
     Unlock West Desert Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Sand Oasis Middle: Nothing
 
 - name: Desert Gorge Statue
   events:
     Unlock Desert Gorge Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Temple of Time South: Nothing
 
 - name: Temple of Time Statue
   events:
     Unlock Temple of Time Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Temple of Time West Past Rubble: Nothing
 
 - name: North Desert Statue
   events:
     Unlock North Desert Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Lanayru Desert North: Nothing
 
 - name: Stone Cache Statue
   events:
     Unlock Stone Cache Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Lanayru Desert East: Nothing
 
 - name: Ancient Harbour Statue
   events:
     Unlock Ancient Harbour Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Ancient Harbour: Nothing
 
 - name: Skipper's Retreat Statue
   events:
     Unlock Skippers Retreat Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Skipper's Retreat Dock: Nothing
 
 - name: Shipyard Statue
   events:
     Unlock Shipyard Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Shipyard Dock: Nothing
 
 - name: Pirate Stronghold Statue
   events:
     Unlock Pirate Stronghold Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Pirate Stronghold Dock: Nothing
 
 - name: Lanayru Gorge Statue
   events:
     Unlock Lanayru Gorge Statue: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Lanayru Gorge: Nothing

--- a/data/world/Lanayru.yaml
+++ b/data/world/Lanayru.yaml
@@ -587,82 +587,82 @@
   events:
     Unlock Lanayru Mine Entry Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Lanayru Mine Entry: Nothing
 
 - name: Desert Entrance Statue
   events:
     Unlock Desert Entrance Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Lanayru Desert South: Nothing
 
 - name: West Desert Statue
   events:
     Unlock West Desert Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Sand Oasis Middle: Nothing
 
 - name: Desert Gorge Statue
   events:
     Unlock Desert Gorge Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Temple of Time South: Nothing
 
 - name: Temple of Time Statue
   events:
     Unlock Temple of Time Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Temple of Time West Past Rubble: Nothing
 
 - name: North Desert Statue
   events:
     Unlock North Desert Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Lanayru Desert North: Nothing
 
 - name: Stone Cache Statue
   events:
     Unlock Stone Cache Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Lanayru Desert East: Nothing
 
 - name: Ancient Harbour Statue
   events:
     Unlock Ancient Harbour Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Ancient Harbour: Nothing
 
 - name: Skipper's Retreat Statue
   events:
     Unlock Skippers Retreat Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Skipper's Retreat Dock: Nothing
 
 - name: Shipyard Statue
   events:
     Unlock Shipyard Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Shipyard Dock: Nothing
 
 - name: Pirate Stronghold Statue
   events:
     Unlock Pirate Stronghold Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Pirate Stronghold Dock: Nothing
 
 - name: Lanayru Gorge Statue
   events:
     Unlock Lanayru Gorge Statue: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Lanayru Gorge: Nothing

--- a/data/world/Sandship.yaml
+++ b/data/world/Sandship.yaml
@@ -1,6 +1,3 @@
-# allowed_time_of_day: DayOnly
-# hint_region: Sandship
-
 - name: Sandship Main Deck
   dungeon: Sandship
   dungeon_starting_area: true

--- a/data/world/Sky Keep.yaml
+++ b/data/world/Sky Keep.yaml
@@ -1,6 +1,3 @@
-# allowed_time_of_day: DayOnly
-# hint_region: Sky Keep
-
 - name: Sky Keep Entryway
   dungeon: Sky Keep
   dungeon_starting_area: true

--- a/data/world/Sky.yaml
+++ b/data/world/Sky.yaml
@@ -101,7 +101,7 @@
   events:
     Can Play Clean Cut Minigame: Sword
   exits:
-    Bamboo Island: Day or or natural_night_connections == off
+    Bamboo Island: Day or natural_night_connections == off
   locations:
     Bamboo Island Interior - Gossip Stone behind Bamboo Pole: Nothing
     Bamboo Island Interior - Bonk Southwest Sprout: Nothing

--- a/data/world/Sky.yaml
+++ b/data/world/Sky.yaml
@@ -89,7 +89,7 @@
   hint_region: Sky
   exits:
     Bamboo Island Interior: Nothing
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Bamboo Island - Slingshot Left Lantern: Slingshot
     Bamboo Island - Slingshot Middle Lantern: Slingshot
@@ -101,7 +101,7 @@
   events:
     Can Play Clean Cut Minigame: Sword
   exits:
-    Bamboo Island: Day
+    Bamboo Island: Day or or or natural_night_connections == off
   locations:
     Bamboo Island Interior - Gossip Stone behind Bamboo Pole: Nothing
     Bamboo Island Interior - Bonk Southwest Sprout: Nothing
@@ -115,7 +115,7 @@
   events:
     Can Collect Water: Bottle
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Island near Bamboo Island - Top Goddess Chest: Eldin_Volcano_Goddess_Cube_near_Mogma_Turf_Entrance
     Island near Bamboo Island - Goddess Chest in Cave: Water_Dragons_Scale and Lanayru_Desert_Goddess_Cube_in_Secret_Passageway
@@ -126,18 +126,18 @@
   hint_region: Sky
   exits:
     Beedle's Airshop: Night
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Beedle's Island - Crystal on Airshop Propeller: Night and Beetle
     Beedle's Island - Deliver Beedle's Insect Cage: Night and Beedles_Insect_Cage
-    Beedle's Island - Top Goddess Chest: Day and Temple_of_Time_Goddess_Cube
-    Beedle's Island - Goddess Chest in Cage: (Night or (Day and logic_beedles_island_cage_chest_dive)) and Deep_Woods_Goddess_Cube_on_top_of_Temple
+    Beedle's Island - Top Goddess Chest: (Day or or natural_night_connections == off) and Temple_of_Time_Goddess_Cube
+    Beedle's Island - Goddess Chest in Cage: (Night or ((Day or or natural_night_connections == off) and logic_beedles_island_cage_chest_dive)) and Deep_Woods_Goddess_Cube_on_top_of_Temple
 
 
 - name: Northeast Island
   hint_region: Sky
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Northeast Island - Goddess Chest behind Bombable Rocks: Bomb_Bag and Lanayru_Mine_Goddess_Cube_behind_First_Landing_Robot
     Northeast Island - Goddess Chest in Cage: Eldin_Volcano_Goddess_Cube_East_of_Temple
@@ -153,7 +153,7 @@
     Lumpy Pumpkin Back Door Exterior: Nothing
     Lumpy Pumpkin Main East Door Exterior: Nothing
     Lumpy Pumpkin Main West Door Exterior: Nothing
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Lumpy Pumpkin - Slingshot Left Porch Lantern: Slingshot
     Lumpy Pumpkin - Slingshot Right Porch Lantern: Slingshot
@@ -162,7 +162,7 @@
     Lumpy Pumpkin - Slingshot Lantern next to Back Door: Slingshot
     Lumpy Pumpkin - Outside Crystal: Night
     Lumpy Pumpkin - Goddess Chest near Gossip Stone: Deep_Woods_Goddess_Cube_near_Goron
-    Lumpy Pumpkin - Goddess Chest on Roof: Day and Skyview_Spring_Goddess_Cube
+    Lumpy Pumpkin - Goddess Chest on Roof: (Day or or natural_night_connections == off) and Skyview_Spring_Goddess_Cube
     Lumpy Pumpkin - Deliver Mogma to Kina: Day and 'Pick_up_Guld'
     Lumpy Pumpkin - Gossip Stone near Back Door: Nothing
 
@@ -225,7 +225,7 @@
 - name: Island Closest to Faron Pillar
   hint_region: Sky
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Island Closest to Faron Pillar - Goddess Chest: Deep_Woods_Goddess_Cube_in_front_of_Temple
 
@@ -235,7 +235,7 @@
   events:
     Mushroom Spores: Nothing
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Volcanic Island - Outside Goddess Chest: Lanayru_Desert_Goddess_Cube_in_Sand_Oasis
     Volcanic Island - Inside Goddess Chest: (Clawshots or logic_volcanic_island_dive) and Faron_Woods_Goddess_Cube_on_East_Great_Tree_with_Clawshots_Target
@@ -245,10 +245,10 @@
 - name: Orielle's Island
   hint_region: Sky
   events:
-    Talk to Orielle: Nothing
-    Save Orielle: Bottle and 'Mushroom_Spores'
+    Talk to Orielle: Day
+    Save Orielle: Day and Bottle and 'Mushroom_Spores'
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Orielle's Island - Heal Orielle's Loftwing: "'Save_Orielle'"
 
@@ -256,35 +256,33 @@
 - name: Fun Fun Island
   hint_region: Sky
   events:
-    Start Dodohs Quest: Nothing
-    Can Play Fun Fun Island Minigame: "'Retrieve_Party_Wheel'"
+    Can Play Fun Fun Island Minigame: Day and 'Retrieve_Party_Wheel'
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
-    Fun Fun Island - Deliver Party Wheel to Dodoh: "'Retrieve_Party_Wheel'"
+    Fun Fun Island - Deliver Party Wheel to Dodoh: Day and 'Retrieve_Party_Wheel'
     Fun Fun Island - 500 Rupees in Dodoh's High Dive: "'Can_Play_Fun_Fun_Island_Minigame'"
-    Fun Fun Island - Goddess Chest below Island: Day and Floria_Waterfall_Goddess_Cube_on_High_Ledge
+    Fun Fun Island - Goddess Chest below Island: (Day or or natural_night_connections == off) and Floria_Waterfall_Goddess_Cube_on_High_Ledge
 
 
 - name: Triple Island
   hint_region: Sky
   exits:
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Triple Island - Upper Goddess Chest: Eldin_Volcano_Goddess_Cube_at_Eldin_Entrance
     Triple Island - Lower Goddess Chest: Lanayru_Desert_Goddess_Cube_near_Caged_Robot
     Triple Island - Goddess Chest in Cage: Clawshots and Skippers_Retreat_Goddess_Cube
 
-# TODO: Check day/night stuff
 - name: Inside the Thunderhead
-  allowed_time_of_day: Day Only
+  allowed_time_of_day: Day Only # The loadzone works but the light beam isn't there
   hint_region: Inside the Thunderhead
   exits:
     Inside the Thunderhead East Island: Nothing
     Isle of Songs: Nothing
     Mogma Mitts Island: Nothing
     Bug Heaven: Nothing
-    The Sky: (Goddesss_Harp and Ballad_of_the_Goddess and can_access(Central Skyloft)) or open_thunderhead == on
+    The Sky: Day and ((Goddesss_Harp and Ballad_of_the_Goddess and can_access(Central Skyloft)) or open_thunderhead == on)
   locations:
     Inside the Thunderhead - Song from Levias: Spiral_Charge and Scrapper and Sword and 'Pick_up_Levias_Soup'
     Inside the Thunderhead - Gossip Stone near Bug Heaven: Nothing
@@ -293,11 +291,11 @@
 - name: Isle of Songs
   hint_region: Inside the Thunderhead
   exits:
-    Inside the Thunderhead: Day
+    Inside the Thunderhead: Day or or natural_night_connections == off
     Isle of Songs Interior: Sword or Distance_Activator or Whip or shortcut_ios_bridge_complete # bomb bag doesn't work
   locations:
-    Isle of Songs - Top Goddess Chest: Day and Volcano_Summit_Goddess_Cube_near_Fire_Sanctuary_Entrance
-    Isle of Songs - Lower Goddess Chest: Day and Mogma_Turf_Goddess_Cube_on_Raised_Pillar
+    Isle of Songs - Top Goddess Chest: (Day or or natural_night_connections == off) and Volcano_Summit_Goddess_Cube_near_Fire_Sanctuary_Entrance
+    Isle of Songs - Lower Goddess Chest: (Day or or natural_night_connections == off) and Mogma_Turf_Goddess_Cube_on_Raised_Pillar
 
 
 - name: Isle of Songs Interior
@@ -312,7 +310,7 @@
 - name: Inside the Thunderhead East Island
   hint_region: Inside the Thunderhead
   exits:
-    Inside the Thunderhead: Day
+    Inside the Thunderhead: Day or or natural_night_connections == off
   locations:
     Inside the Thunderhead - Chest on East Island: Digging_Mitts or logic_east_island_dive
     Inside the Thunderhead - Goddess Chest on East Island: Faron_Woods_Goddess_Cube_on_East_Great_Tree_with_Rope
@@ -321,7 +319,7 @@
 - name: Mogma Mitts Island
   hint_region: Inside the Thunderhead
   exits:
-    Inside the Thunderhead: Day
+    Inside the Thunderhead: Day or or natural_night_connections == off
   locations:
     Inside the Thunderhead - Mogma Mitts Island First Goddess Chest: Mogma_Mitts and Volcano_Summit_Goddess_Cube_in_Lava_Lake
     Inside the Thunderhead - Mogma Mitts Island Second Goddess Chest: Mogma_Mitts and Lanayru_Gorge_Goddess_Cube
@@ -332,7 +330,7 @@
   events:
     Can Collect Water: Bottle
   exits:
-    Inside the Thunderhead: Day
+    Inside the Thunderhead: Day or or natural_night_connections == off
   locations:
     Bug Heaven - 10 Bugs in 3 Minutes: (Bug_Net and (minigame_difficulty == vanilla or minigame_difficulty == hard)) or Big_Bug_Net
     Bug Heaven - Goddess Chest: Volcano_Summit_Goddess_Cube_at_Summit_Waterfall

--- a/data/world/Sky.yaml
+++ b/data/world/Sky.yaml
@@ -89,7 +89,7 @@
   hint_region: Sky
   exits:
     Bamboo Island Interior: Nothing
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Bamboo Island - Slingshot Left Lantern: Slingshot
     Bamboo Island - Slingshot Middle Lantern: Slingshot
@@ -101,7 +101,7 @@
   events:
     Can Play Clean Cut Minigame: Sword
   exits:
-    Bamboo Island: Day or or or natural_night_connections == off
+    Bamboo Island: Day or or natural_night_connections == off
   locations:
     Bamboo Island Interior - Gossip Stone behind Bamboo Pole: Nothing
     Bamboo Island Interior - Bonk Southwest Sprout: Nothing
@@ -115,7 +115,7 @@
   events:
     Can Collect Water: Bottle
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Island near Bamboo Island - Top Goddess Chest: Eldin_Volcano_Goddess_Cube_near_Mogma_Turf_Entrance
     Island near Bamboo Island - Goddess Chest in Cave: Water_Dragons_Scale and Lanayru_Desert_Goddess_Cube_in_Secret_Passageway
@@ -126,18 +126,18 @@
   hint_region: Sky
   exits:
     Beedle's Airshop: Night
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Beedle's Island - Crystal on Airshop Propeller: Night and Beetle
     Beedle's Island - Deliver Beedle's Insect Cage: Night and Beedles_Insect_Cage
-    Beedle's Island - Top Goddess Chest: (Day or or natural_night_connections == off) and Temple_of_Time_Goddess_Cube
-    Beedle's Island - Goddess Chest in Cage: (Night or ((Day or or natural_night_connections == off) and logic_beedles_island_cage_chest_dive)) and Deep_Woods_Goddess_Cube_on_top_of_Temple
+    Beedle's Island - Top Goddess Chest: (Day or natural_night_connections == off) and Temple_of_Time_Goddess_Cube
+    Beedle's Island - Goddess Chest in Cage: (Night or ((Day or natural_night_connections == off) and logic_beedles_island_cage_chest_dive)) and Deep_Woods_Goddess_Cube_on_top_of_Temple
 
 
 - name: Northeast Island
   hint_region: Sky
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Northeast Island - Goddess Chest behind Bombable Rocks: Bomb_Bag and Lanayru_Mine_Goddess_Cube_behind_First_Landing_Robot
     Northeast Island - Goddess Chest in Cage: Eldin_Volcano_Goddess_Cube_East_of_Temple
@@ -153,7 +153,7 @@
     Lumpy Pumpkin Back Door Exterior: Nothing
     Lumpy Pumpkin Main East Door Exterior: Nothing
     Lumpy Pumpkin Main West Door Exterior: Nothing
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Lumpy Pumpkin - Slingshot Left Porch Lantern: Slingshot
     Lumpy Pumpkin - Slingshot Right Porch Lantern: Slingshot
@@ -162,7 +162,7 @@
     Lumpy Pumpkin - Slingshot Lantern next to Back Door: Slingshot
     Lumpy Pumpkin - Outside Crystal: Night
     Lumpy Pumpkin - Goddess Chest near Gossip Stone: Deep_Woods_Goddess_Cube_near_Goron
-    Lumpy Pumpkin - Goddess Chest on Roof: (Day or or natural_night_connections == off) and Skyview_Spring_Goddess_Cube
+    Lumpy Pumpkin - Goddess Chest on Roof: (Day or natural_night_connections == off) and Skyview_Spring_Goddess_Cube
     Lumpy Pumpkin - Deliver Mogma to Kina: Day and 'Pick_up_Guld'
     Lumpy Pumpkin - Gossip Stone near Back Door: Nothing
 
@@ -225,7 +225,7 @@
 - name: Island Closest to Faron Pillar
   hint_region: Sky
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Island Closest to Faron Pillar - Goddess Chest: Deep_Woods_Goddess_Cube_in_front_of_Temple
 
@@ -235,7 +235,7 @@
   events:
     Mushroom Spores: Nothing
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Volcanic Island - Outside Goddess Chest: Lanayru_Desert_Goddess_Cube_in_Sand_Oasis
     Volcanic Island - Inside Goddess Chest: (Clawshots or logic_volcanic_island_dive) and Faron_Woods_Goddess_Cube_on_East_Great_Tree_with_Clawshots_Target
@@ -248,7 +248,7 @@
     Talk to Orielle: Day
     Save Orielle: Day and Bottle and 'Mushroom_Spores'
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Orielle's Island - Heal Orielle's Loftwing: "'Save_Orielle'"
 
@@ -258,17 +258,17 @@
   events:
     Can Play Fun Fun Island Minigame: Day and 'Retrieve_Party_Wheel'
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Fun Fun Island - Deliver Party Wheel to Dodoh: Day and 'Retrieve_Party_Wheel'
     Fun Fun Island - 500 Rupees in Dodoh's High Dive: "'Can_Play_Fun_Fun_Island_Minigame'"
-    Fun Fun Island - Goddess Chest below Island: (Day or or natural_night_connections == off) and Floria_Waterfall_Goddess_Cube_on_High_Ledge
+    Fun Fun Island - Goddess Chest below Island: (Day or natural_night_connections == off) and Floria_Waterfall_Goddess_Cube_on_High_Ledge
 
 
 - name: Triple Island
   hint_region: Sky
   exits:
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Triple Island - Upper Goddess Chest: Eldin_Volcano_Goddess_Cube_at_Eldin_Entrance
     Triple Island - Lower Goddess Chest: Lanayru_Desert_Goddess_Cube_near_Caged_Robot
@@ -291,11 +291,11 @@
 - name: Isle of Songs
   hint_region: Inside the Thunderhead
   exits:
-    Inside the Thunderhead: Day or or natural_night_connections == off
+    Inside the Thunderhead: Day or natural_night_connections == off
     Isle of Songs Interior: Sword or Distance_Activator or Whip or shortcut_ios_bridge_complete # bomb bag doesn't work
   locations:
-    Isle of Songs - Top Goddess Chest: (Day or or natural_night_connections == off) and Volcano_Summit_Goddess_Cube_near_Fire_Sanctuary_Entrance
-    Isle of Songs - Lower Goddess Chest: (Day or or natural_night_connections == off) and Mogma_Turf_Goddess_Cube_on_Raised_Pillar
+    Isle of Songs - Top Goddess Chest: (Day or natural_night_connections == off) and Volcano_Summit_Goddess_Cube_near_Fire_Sanctuary_Entrance
+    Isle of Songs - Lower Goddess Chest: (Day or natural_night_connections == off) and Mogma_Turf_Goddess_Cube_on_Raised_Pillar
 
 
 - name: Isle of Songs Interior
@@ -310,7 +310,7 @@
 - name: Inside the Thunderhead East Island
   hint_region: Inside the Thunderhead
   exits:
-    Inside the Thunderhead: Day or or natural_night_connections == off
+    Inside the Thunderhead: Day or natural_night_connections == off
   locations:
     Inside the Thunderhead - Chest on East Island: Digging_Mitts or logic_east_island_dive
     Inside the Thunderhead - Goddess Chest on East Island: Faron_Woods_Goddess_Cube_on_East_Great_Tree_with_Rope
@@ -319,7 +319,7 @@
 - name: Mogma Mitts Island
   hint_region: Inside the Thunderhead
   exits:
-    Inside the Thunderhead: Day or or natural_night_connections == off
+    Inside the Thunderhead: Day or natural_night_connections == off
   locations:
     Inside the Thunderhead - Mogma Mitts Island First Goddess Chest: Mogma_Mitts and Volcano_Summit_Goddess_Cube_in_Lava_Lake
     Inside the Thunderhead - Mogma Mitts Island Second Goddess Chest: Mogma_Mitts and Lanayru_Gorge_Goddess_Cube
@@ -330,7 +330,7 @@
   events:
     Can Collect Water: Bottle
   exits:
-    Inside the Thunderhead: Day or or natural_night_connections == off
+    Inside the Thunderhead: Day or natural_night_connections == off
   locations:
     Bug Heaven - 10 Bugs in 3 Minutes: (Bug_Net and (minigame_difficulty == vanilla or minigame_difficulty == hard)) or Big_Bug_Net
     Bug Heaven - Goddess Chest: Volcano_Summit_Goddess_Cube_at_Summit_Waterfall

--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -194,7 +194,7 @@
     Peatrice's House: Nothing
     Kukiel's House: Nothing
     Piper's House: Nothing
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Upper Skyloft: Nothing
     Skyloft Village: Nothing
     # omit SoT here intentionally, see the comment on that
@@ -366,7 +366,7 @@
   allowed_time_of_day: All
   exits:
     Waterfall Cave: Nothing
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
   locations:
     Central Skyloft - Crystal near Bird Statue after Waterfall Cave: Night
     Central Skyloft - Crystal in Loftwing Prison after Waterfall Cave: Night
@@ -402,7 +402,7 @@
     Gondo's House: Nothing
     Rupin's House: Nothing
     Batreaux's House: open_batreaux_shed or 'Opened_Shed' or logic_gravestone_jump
-    The Sky: Day
+    The Sky: Day or or natural_night_connections == off
     Skyloft Past Waterfall Cave Jump: logic_waterfall_cave_jump and Day
     Central Skyloft: Nothing
   locations:

--- a/data/world/Skyloft.yaml
+++ b/data/world/Skyloft.yaml
@@ -194,7 +194,7 @@
     Peatrice's House: Nothing
     Kukiel's House: Nothing
     Piper's House: Nothing
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Upper Skyloft: Nothing
     Skyloft Village: Nothing
     # omit SoT here intentionally, see the comment on that
@@ -366,7 +366,7 @@
   allowed_time_of_day: All
   exits:
     Waterfall Cave: Nothing
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
   locations:
     Central Skyloft - Crystal near Bird Statue after Waterfall Cave: Night
     Central Skyloft - Crystal in Loftwing Prison after Waterfall Cave: Night
@@ -402,7 +402,7 @@
     Gondo's House: Nothing
     Rupin's House: Nothing
     Batreaux's House: open_batreaux_shed or 'Opened_Shed' or logic_gravestone_jump
-    The Sky: Day or or natural_night_connections == off
+    The Sky: Day or natural_night_connections == off
     Skyloft Past Waterfall Cave Jump: logic_waterfall_cave_jump and Day
     Central Skyloft: Nothing
   locations:


### PR DESCRIPTION
## What does this address?

The logic didn't consider that some entrances with a "Day" requirement can be bypassed when `natural_night_connections` is turned off.


## How did/do you test these changes?

I started the tracker with default settings + door ER + `natural_night_connections` turned off. I assigned the lower academy door to the back lumpy door. The logic for the night time crystals no longer required an entrance to be found but rather required a distance activator (academy -> outside lumpy -> skyloft -> shoot beedle bell -> sleep to night -> exit to sky -> fly back to skyloft -> collect crystals).

More trivial cases also worked as expected. I also tested the same settings with `natural_night_connections` enabled and the logic required a direct access to a bed as normal.