### PR TITLE
Prevent presets changing prefs

### DIFF
--- a/gui/advanced.py
+++ b/gui/advanced.py
@@ -9,8 +9,6 @@ from PySide6.QtWidgets import (
     QComboBox,
     QLineEdit,
     QFileDialog,
-    QSpacerItem,
-    QSizePolicy,
 )
 
 from filepathconstants import (
@@ -20,7 +18,6 @@ from filepathconstants import (
     SPOILER_LOGS_PATH,
     SSHD_EXTRACT_PATH,
     OTHER_MODS_PATH,
-    COMBINED_MODS_FOLDER,
 )
 from gui.dialogs.error_dialog import error_from_str
 from gui.dialogs.verify_files_progress_dialog import VerifyFilesProgressDialog
@@ -67,7 +64,7 @@ class Advanced:
             partial(self.verify_extract, verify_all=True)
         )
 
-        self.ui.refresh_mod_list_button.clicked.connect(self.generate_other_mods_list)
+        self.ui.refresh_mod_list_button.clicked.connect(self.main.settings.generate_other_mods_list)
 
         self.verify_dialog = None
 
@@ -121,7 +118,7 @@ class Advanced:
         self.open_other_mods_dir_button.clicked.connect(self.open_other_mods_directory)
 
         # Other mods
-        self.generate_other_mods_list()
+        self.main.settings.generate_other_mods_list()
 
     def update_config(self):
         write_config_to_file(CONFIG_PATH, self.config)
@@ -240,56 +237,6 @@ class Advanced:
             self.show_file_error_dialog(
                 "Could not open or create the 'other_mods' folder.\n\nThe 'other_mods' folder should be in the same folder as this randomizer program."
             )
-
-    def generate_other_mods_list(self):
-        self.main.clear_layout(self.ui.other_mods_scroll_layout)
-        found_mods = []
-        for mod_path in OTHER_MODS_PATH.glob("*"):
-            if mod_path.is_dir():
-                mod_name = mod_path.name
-
-                # Don't include the combined mods folder as a mod folder. Normally this folder is deleted, but
-                # if generation fails for some reason, then it might not get deleted.
-                if mod_name == COMBINED_MODS_FOLDER:
-                    continue
-
-                # Don't include the mod if it has an exefs folder. We don't support integrating other mods which modify code
-                if (OTHER_MODS_PATH / mod_name / "exefs").exists():
-                    continue
-
-                mod_checkbox = QCheckBox(mod_name)
-                mod_checkbox.clicked.connect(self.update_mods_in_config)
-                if mod_name in self.config.settings[0].other_mods:
-                    mod_checkbox.setChecked(True)
-                    found_mods.append(mod_name)
-
-                self.ui.other_mods_scroll_layout.addWidget(mod_checkbox)
-
-        # Add a vertical spacer to push the mod list up
-        self.ui.other_mods_scroll_layout.addSpacerItem(
-            QSpacerItem(
-                20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
-            )
-        )
-
-        # Remove mods from config which weren't found
-        for mod_name in self.config.settings[0].other_mods.copy():
-            if mod_name not in found_mods:
-                print(
-                    f"Removing mod {mod_name} from other_mods list as the QCheckbox for the mod could not be found"
-                )
-                self.config.settings[0].other_mods.remove(mod_name)
-
-        self.update_config()
-
-    def update_mods_in_config(self):
-        other_mods = self.config.settings[0].other_mods
-        other_mods.clear()
-        for checkbox in self.ui.other_mods_scroll_widget.findChildren(QCheckBox):
-            if checkbox.isChecked():
-                other_mods.append(checkbox.text())
-
-        self.update_config()
 
     def cancel_callback(self):
         VerificationThread.cancelled = True

--- a/gui/advanced.py
+++ b/gui/advanced.py
@@ -64,7 +64,9 @@ class Advanced:
             partial(self.verify_extract, verify_all=True)
         )
 
-        self.ui.refresh_mod_list_button.clicked.connect(self.main.settings.generate_other_mods_list)
+        self.ui.refresh_mod_list_button.clicked.connect(
+            self.main.settings.generate_other_mods_list
+        )
 
         self.verify_dialog = None
 

--- a/gui/settings.py
+++ b/gui/settings.py
@@ -260,7 +260,7 @@ class Settings:
             except:
                 pass
 
-            if isinstance(widget, RandoTriStateCheckBox):  # on or off
+            if isinstance(widget, RandoTriStateCheckBox):
                 if current_option_value == "on":
                     widget.setChecked(True)
                 elif current_option_value == "random":
@@ -460,7 +460,7 @@ class Settings:
             except:
                 pass
 
-            if isinstance(widget, QCheckBox):  # on or off
+            if isinstance(widget, QCheckBox):
                 if current_option_value == "on":
                     widget.setChecked(True)
                 elif current_option_value == "random":
@@ -882,14 +882,15 @@ class Settings:
             else:
                 selected_preset_path = PRESETS_PATH / (selected_preset + ".yaml")
 
-            self.config = load_config_from_file(selected_preset_path)
+            self.config = load_config_from_file(
+                selected_preset_path, config=self.config
+            )
             self.verify_excluded_locations()
             write_config_to_file(selected_preset_path, self.config)
             self.settings = self.config.settings[0].settings
 
             self.new_seed()
             self.update_from_config()
-            self.main.config = self.config  # ¯\_(ツ)_/¯
 
     def update_hash(self):
         self.config.hash = ""

--- a/gui/settings.py
+++ b/gui/settings.py
@@ -28,7 +28,14 @@ from constants.itemconstants import (
     GRATITUDE_CRYSTAL,
     GROUP_OF_TADTONES,
 )
-from filepathconstants import BASE_PRESETS_PATH, COMBINED_MODS_FOLDER, CONFIG_PATH, ITEMS_PATH, OTHER_MODS_PATH, PRESETS_PATH
+from filepathconstants import (
+    BASE_PRESETS_PATH,
+    COMBINED_MODS_FOLDER,
+    CONFIG_PATH,
+    ITEMS_PATH,
+    OTHER_MODS_PATH,
+    PRESETS_PATH,
+)
 from gui.components.list_pair import ListPair
 from gui.components.tristate_check_box import RandoTriStateCheckBox
 from gui.mixed_entrance_pools import MixedEntrancePools

--- a/logic/config.py
+++ b/logic/config.py
@@ -215,6 +215,7 @@ def load_or_get_default_from_config(config: dict, setting_name: str):
 
 def load_config_from_file(
     filepath: Path,
+    config: Config | None = None,
     allow_rewrite: bool = True,
     create_if_blank: bool = False,
     default_on_invalid_value: bool = False,
@@ -223,7 +224,8 @@ def load_config_from_file(
         print("No config file found. Creating default config file.")
         create_default_config(filepath)
 
-    config = load_preferences()
+    config = load_preferences(config)
+
     # If the config is missing any options, set defaults and resave it afterwards
     rewrite_config: bool = False
     with open(filepath, encoding="utf-8") as config_file:
@@ -248,6 +250,9 @@ def load_config_from_file(
         # Create default World 1 if it doesn't exist already
         if world_num_str not in config_in:
             config_in[world_num_str] = {}
+
+        # If config was passed into this function, clear the setting and start over
+        config.settings.clear()
 
         settings_info = get_all_settings_info()
         while world_num_str in config_in:
@@ -417,8 +422,10 @@ def load_config_from_file(
     return config
 
 
-def load_preferences() -> Config:
-    config = Config()
+def load_preferences(config: Config | None = None) -> Config:
+    if config is None:
+        config = Config()
+
     filepath = Path(PREFERENCES_PATH)
 
     if not filepath.is_file():


### PR DESCRIPTION
## What does this address?

* Fixes the issue where loading a preset would cause any preferences to be reset when changing any setting in the GUI.
* Fixes the issue where the other mods list wouldn't update correctly when loading a preset or pasting a setting string.


## How did/do you test these changes?

Applying a preset, changing the output directory, and then toggling a setting didn't cause the output directory to be reset in `preferences.yaml`.

I tested enabling some other mods and then applying a preset. The other mods were removed from the config.yaml and the GUI showed no other mods enabled. I tested enabling some other mods and then pasted in a different setting string. The other mods were still enabled both in the config file and the GUI.

I tried genning a seed with several other mods enabled through the GUI and I was able to confirm they were correctly applied when I started the seed. I then turned off the other mods in the GUI and genned a seed. The second seed didn't have any other mods applied.
