### PR TITLE
Allow the damage_multiplier setting to be set to zero

### DIFF
--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -841,9 +841,9 @@
   random_low: "1"
   random_high: "4"
   pretty_options:
-    - 1-80
+    - 0-80
   options:
-    - 1-80: "Determines the overall damage multiplier.
+    - 0-80: "Determines the overall damage multiplier.
         <b>Normal Mode</b> (default) damage is x1.
         <b>Hero Mode</b> (new game +) damage is x2.
         At x12 or higher, the hot cave in Eldin Volcano logically requires Fireshield Earrings to traverse."


### PR DESCRIPTION
## What does this address?

Lowers the minimum value for the `damage_multiplier` setting from 1 to zero.


## How did/do you test these changes?

I tested the `damage_multiplier` setting while set to 0, 1, 2, and 3. Taking damage with a bomb did 0, 1, 2, and 3 hearts of damage respectively.
