### PR TITLE
Move the Groosenator destinations setting to the advanced tab of the GUI

### DIFF
--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -1068,13 +1068,6 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_14">
            <item>
-            <widget class="RandoTriStateCheckBox" name="setting_unlock_all_groosenator_destinations">
-             <property name="text">
-              <string>Unlock all Groosenator Destinations</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="RandoTriStateCheckBox" name="setting_open_thunderhead">
              <property name="text">
               <string>Open Thunderhead</string>
@@ -3856,6 +3849,13 @@ Practice Sword</string>
             <widget class="RandoTriStateCheckBox" name="setting_natural_night_connections">
              <property name="text">
               <string>Require Natural Night Connections</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="RandoTriStateCheckBox" name="setting_unlock_all_groosenator_destinations">
+             <property name="text">
+              <string>Unlock all Groosenator Destinations</string>
              </property>
             </widget>
            </item>

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -737,11 +737,6 @@ class Ui_main_window(object):
         self.open_world_group_box.setObjectName(u"open_world_group_box")
         self.verticalLayout_14 = QVBoxLayout(self.open_world_group_box)
         self.verticalLayout_14.setObjectName(u"verticalLayout_14")
-        self.setting_unlock_all_groosenator_destinations = RandoTriStateCheckBox(self.open_world_group_box)
-        self.setting_unlock_all_groosenator_destinations.setObjectName(u"setting_unlock_all_groosenator_destinations")
-
-        self.verticalLayout_14.addWidget(self.setting_unlock_all_groosenator_destinations)
-
         self.setting_open_thunderhead = RandoTriStateCheckBox(self.open_world_group_box)
         self.setting_open_thunderhead.setObjectName(u"setting_open_thunderhead")
 
@@ -2531,6 +2526,11 @@ class Ui_main_window(object):
 
         self.verticalLayout_32.addWidget(self.setting_natural_night_connections)
 
+        self.setting_unlock_all_groosenator_destinations = RandoTriStateCheckBox(self.other_settings_group_box)
+        self.setting_unlock_all_groosenator_destinations.setObjectName(u"setting_unlock_all_groosenator_destinations")
+
+        self.verticalLayout_32.addWidget(self.setting_unlock_all_groosenator_destinations)
+
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout_32.addItem(self.verticalSpacer)
@@ -3055,6 +3055,7 @@ class Ui_main_window(object):
 
         self.tab_widget.setCurrentIndex(0)
 
+
         QMetaObject.connectSlotsByName(main_window)
     # setupUi
 
@@ -3129,7 +3130,6 @@ class Ui_main_window(object):
         self.setting_skip_demise.setText(QCoreApplication.translate("main_window", u"Skip Demise Fight", None))
         self.tab_widget.setTabText(self.tab_widget.indexOf(self.gameplay_tab), QCoreApplication.translate("main_window", u"Gameplay", None))
         self.open_world_group_box.setTitle(QCoreApplication.translate("main_window", u"Open World", None))
-        self.setting_unlock_all_groosenator_destinations.setText(QCoreApplication.translate("main_window", u"Unlock all Groosenator Destinations", None))
         self.setting_open_thunderhead.setText(QCoreApplication.translate("main_window", u"Open Thunderhead", None))
         self.open_lake_floria_label.setText(QCoreApplication.translate("main_window", u"Open Lake Floria", None))
         self.setting_open_batreaux_shed.setText(QCoreApplication.translate("main_window", u"Open Batreaux's Shed", None))
@@ -3353,6 +3353,7 @@ class Ui_main_window(object):
         self.setting_enable_back_in_time.setText(QCoreApplication.translate("main_window", u"Enable Back in Time (BiT)", None))
         self.setting_allow_flying_at_night.setText(QCoreApplication.translate("main_window", u"Allow Flying at Night", None))
         self.setting_natural_night_connections.setText(QCoreApplication.translate("main_window", u"Require Natural Night Connections", None))
+        self.setting_unlock_all_groosenator_destinations.setText(QCoreApplication.translate("main_window", u"Unlock all Groosenator Destinations", None))
         self.other_mods_group_box.setTitle(QCoreApplication.translate("main_window", u"Other Mods", None))
         self.other_mods_explanation_text.setText(QCoreApplication.translate("main_window", u"<html><head/><body><p>The randomizer modifies a lot of files the game uses. To better integrate other mods with the randomizer, you can put them in separate folders in the <span style=\" font-weight:700;\">other_mods</span> directory and choose which ones you want to apply together. For example, if you have a mod which changes Link's tunic color, you can create a new folder in the <span style=\" font-weight:700;\">other_mods</span> directory named &quot;Other Tunic Color&quot; and put the <span style=\" font-weight:700;\">romfs</span> folder of that mod into the new folder. Then refresh the mod list and it should appear below. We do not currently support mods that modify any files in the <span style=\" font-weight:700;\">exefs</span> folder.</p><p>Note that this feature is EXPERIMENTAL and we do not guarantee that you won't run into bugs when using other mods, but the randomizer will try it's best.</p></body></html>", None))
         self.open_other_mods_dir_button.setText(QCoreApplication.translate("main_window", u"Open other_mods Folder", None))


### PR DESCRIPTION
## What does this address?

Moves the `Unlock all Groosenator Destinations` setting to the Advanced tab of the randomizer GUI.


## How did/do you test these changes?

I opened the randomizer and was able to toggle the setting in the advanced tab.
