### PR TITLE
Regional ET Key Pieces

### DIFF
--- a/data/patches/stagepatches.yaml
+++ b/data/patches/stagepatches.yaml
@@ -2206,7 +2206,7 @@ F200: # Eldin Volcano
     room: 4
     objtype: OBJ
   - name: Remove ET Door if open ET
-    onlyif: open_earth_temple == on
+    onlyif: open_earth_temple == open
     type: objdelete
     id: 0x2413
     layer: 0

--- a/data/presets/Beginner.yaml
+++ b/data/presets/Beginner.yaml
@@ -94,7 +94,7 @@ World 1:
   low_health_beeping_speed: normal
   open_thunderhead: 'off'
   open_lake_floria: open
-  open_earth_temple: 'on'
+  open_earth_temple: 'open'
   open_lmf: open
   open_batreaux_shed: 'on'
   shortcut_ios_bridge_complete: 'off'

--- a/data/presets/Chestless.yaml
+++ b/data/presets/Chestless.yaml
@@ -94,7 +94,7 @@ World 1:
   low_health_beeping_speed: normal
   open_thunderhead: 'off'
   open_lake_floria: vanilla
-  open_earth_temple: 'off'
+  open_earth_temple: 'shuffle_eldin'
   open_lmf: open
   open_batreaux_shed: 'on'
   shortcut_ios_bridge_complete: 'off'

--- a/data/presets/Max Settings.yaml
+++ b/data/presets/Max Settings.yaml
@@ -94,7 +94,7 @@ World 1:
   low_health_beeping_speed: normal
   open_thunderhead: 'off'
   open_lake_floria: vanilla
-  open_earth_temple: 'off'
+  open_earth_temple: 'shuffle_anywhere'
   open_lmf: nodes
   open_batreaux_shed: 'on'
   shortcut_ios_bridge_complete: 'off'

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -1156,14 +1156,16 @@
 
 - name: open_earth_temple
   tracker_important: true
-  default_option: "on"
+  default_option: "open"
   pretty_name: Open Earth Temple
   pretty_options:
-    - "Off"
-    - "On"
+    - "Open"
+    - "Shuffle Key Pieces (Eldin)"
+    - "Shuffle Key Pieces (Anywhere)"
   options:
-    - "off": "You will need to collect all the Earth Temple Key Pieces in order to open the Earth Temple Door."
-    - "on": "The Earth Temple Door will be opened from the start of the game."
+    - "open": "The Earth Temple Door will be opened from the start of the game."
+    - "shuffle_eldin": "You will need to collect all the Earth Temple Key Pieces, shuffled within the Eldin Volcanoe region, in order to open the Earth Temple Door."
+    - "shuffle_anywhere": "You will need to collect all the Earth Temple Key Pieces, shuffled anywhere, in order to open the Earth Temple Door."
 
 - name: open_lmf
   tracker_important: true

--- a/data/settings_list.yaml
+++ b/data/settings_list.yaml
@@ -1164,7 +1164,7 @@
     - "Shuffle Key Pieces (Anywhere)"
   options:
     - "open": "The Earth Temple Door will be opened from the start of the game."
-    - "shuffle_eldin": "You will need to collect all the Earth Temple Key Pieces, shuffled within the Eldin Volcanoe region, in order to open the Earth Temple Door."
+    - "shuffle_eldin": "You will need to collect all the Earth Temple Key Pieces, shuffled within the Eldin Volcano region, in order to open the Earth Temple Door."
     - "shuffle_anywhere": "You will need to collect all the Earth Temple Key Pieces, shuffled anywhere, in order to open the Earth Temple Door."
 
 - name: open_lmf

--- a/data/world/Eldin.yaml
+++ b/data/world/Eldin.yaml
@@ -142,7 +142,7 @@
     Retrieve Crystal Ball: Digging_Mitts and Clawshots and Scrapper and 'Start_Sparrots_Quest'
   exits:
     Temple Entrance Statue: Nothing
-    Earth Temple First Room: open_earth_temple or count(5, Key_Piece)
+    Earth Temple First Room: open_earth_temple == open or count(5, Key_Piece)
     Hot Cave: Nothing # You can use the bomb flower in one of the boko huts to blow up the tower
     Outside Upper Eldin Cave: "'Beaten_Boko_Base'"
     Outside Thrill Digger Cave: can_access(Outside Thrill Digger Cave) or (logic_bomb_throws and Bomb_Bag)

--- a/gui/tracker.py
+++ b/gui/tracker.py
@@ -773,7 +773,7 @@ class Tracker:
 
         # Hide specific inventory buttons depending on settings
         # ET Key Pieces
-        visible = self.world.setting("open_earth_temple") != "on"
+        visible = self.world.setting("open_earth_temple") != "open"
         self.et_key_piece_button.setVisible(visible)
 
         # Small Key buttons

--- a/gui/ui/main.ui
+++ b/gui/ui/main.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1387</width>
-    <height>873</height>
+    <width>1483</width>
+    <height>977</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,7 +36,7 @@
        <enum>QTabWidget::TabShape::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="getting_started_tab">
        <property name="sizePolicy">
@@ -500,7 +500,7 @@
                     </property>
                     <property name="currentFont">
                      <font>
-                      <family>Arial</family>
+                      <family>Arimo</family>
                       <pointsize>10</pointsize>
                      </font>
                     </property>
@@ -1212,11 +1212,14 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_25">
            <item>
-            <widget class="RandoTriStateCheckBox" name="setting_open_earth_temple">
+            <widget class="QLabel" name="open_earth_temple_label">
              <property name="text">
               <string>Open Earth Temple</string>
              </property>
             </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="setting_open_earth_temple"/>
            </item>
            <item>
             <widget class="QLabel" name="open_lmf_label">

--- a/gui/ui/ui_main.py
+++ b/gui/ui/ui_main.py
@@ -29,7 +29,7 @@ class Ui_main_window(object):
     def setupUi(self, main_window):
         if not main_window.objectName():
             main_window.setObjectName(u"main_window")
-        main_window.resize(1387, 873)
+        main_window.resize(1483, 977)
         main_window.setStyleSheet(u"QToolTip {color: #000000; background-color: #FFFFFF;}")
         self.central_widget = QWidget(main_window)
         self.central_widget.setObjectName(u"central_widget")
@@ -310,7 +310,7 @@ class Ui_main_window(object):
         self.font_family_combo_box.setMinimumContentsLength(1)
         self.font_family_combo_box.setFontFilters(QFontComboBox.FontFilter.ScalableFonts)
         font = QFont()
-        font.setFamilies([u"Arial"])
+        font.setFamilies([u"Arimo"])
         font.setPointSize(10)
         self.font_family_combo_box.setCurrentFont(font)
 
@@ -838,7 +838,12 @@ class Ui_main_window(object):
         self.open_dungeons_group_box.setObjectName(u"open_dungeons_group_box")
         self.verticalLayout_25 = QVBoxLayout(self.open_dungeons_group_box)
         self.verticalLayout_25.setObjectName(u"verticalLayout_25")
-        self.setting_open_earth_temple = RandoTriStateCheckBox(self.open_dungeons_group_box)
+        self.open_earth_temple_label = QLabel(self.open_dungeons_group_box)
+        self.open_earth_temple_label.setObjectName(u"open_earth_temple_label")
+
+        self.verticalLayout_25.addWidget(self.open_earth_temple_label)
+
+        self.setting_open_earth_temple = QComboBox(self.open_dungeons_group_box)
         self.setting_open_earth_temple.setObjectName(u"setting_open_earth_temple")
 
         self.verticalLayout_25.addWidget(self.setting_open_earth_temple)
@@ -3053,7 +3058,8 @@ class Ui_main_window(object):
 
         self.retranslateUi(main_window)
 
-        self.tab_widget.setCurrentIndex(0)
+        self.tab_widget.setCurrentIndex(2)
+
 
         QMetaObject.connectSlotsByName(main_window)
     # setupUi
@@ -3147,7 +3153,7 @@ class Ui_main_window(object):
         self.setting_shortcut_sand_oasis_minecart.setText(QCoreApplication.translate("main_window", u"Lanayru Desert Minecart in Sand Oasis", None))
         self.setting_shortcut_minecart_before_caves.setText(QCoreApplication.translate("main_window", u"Lanayru Desert Minecart before Lanayru Caves", None))
         self.open_dungeons_group_box.setTitle(QCoreApplication.translate("main_window", u"Open Dungeons", None))
-        self.setting_open_earth_temple.setText(QCoreApplication.translate("main_window", u"Open Earth Temple", None))
+        self.open_earth_temple_label.setText(QCoreApplication.translate("main_window", u"Open Earth Temple", None))
         self.open_lmf_label.setText(QCoreApplication.translate("main_window", u"Open Lanyru Mining Facility", None))
         self.setting_shortcut_skyview_boards.setText(QCoreApplication.translate("main_window", u"Skyview Temple Boarded Shortcut", None))
         self.setting_shortcut_skyview_bars.setText(QCoreApplication.translate("main_window", u"Skyview Temple Bars before Boss Door", None))

--- a/logic/fill.py
+++ b/logic/fill.py
@@ -362,6 +362,28 @@ def place_own_region_items(world: World, worlds: list[World]):
         complete_item_pool = get_complete_item_pool(worlds)
         assumed_fill(worlds, own_region_items, complete_item_pool, own_region_locations)
 
+    # Own region place Earth Temple Key Pieces if needed
+    if world.setting("open_earth_temple") == "shuffle_eldin":
+        key_piece = world.get_item(KEY_PIECE)
+
+        eldin_locations: list[Location] = []
+        eldin_items: list[Item] = []
+        eldin_items.extend([key_piece] * world.item_pool[key_piece])
+        world.item_pool[key_piece] = 0
+
+        for location in world.get_all_item_locations():
+            if any(
+                la
+                for la in location.loc_access_list
+                if "Eldin Volcano" in la.area.hint_regions
+            ):
+                eldin_locations.append(location)
+
+        # Get the complete item pool for all worlds incase of multiworld
+        # plandomized items that are required to get to Eldin Volcano
+        complete_item_pool = get_complete_item_pool(worlds)
+        assumed_fill(worlds, eldin_items, complete_item_pool, eldin_locations)
+
 
 def place_any_dungeon_items(world: World, worlds: list[World]):
     any_dungeon_items: list[Item] = []

--- a/logic/item_pool.py
+++ b/logic/item_pool.py
@@ -35,7 +35,7 @@ def generate_item_pool(world: "World") -> None:
     item_pool = item_pool.copy()
 
     # Remove Key Pieces if the ET Door is open
-    if world.setting("open_earth_temple") == "on":
+    if world.setting("open_earth_temple") == "open":
         item_pool = [item for item in item_pool if item != KEY_PIECE]
 
     if world.setting("small_keys") == "removed":

--- a/tests/test_configs/open_et_key_pieces_in_eldin.yaml
+++ b/tests/test_configs/open_et_key_pieces_in_eldin.yaml
@@ -1,0 +1,3 @@
+seed: GearHighFloodedKukiel
+World 1:
+  open_earth_temple: shuffle_eldin

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -192,6 +192,26 @@ def test_random_starting_spawn_anywhere() -> None:
     config_test("random_starting_spawn_anywhere.yaml")
 
 
+def test_open_et_key_pieces_in_eldin() -> None:
+    worlds = config_test("open_et_key_pieces_in_eldin.yaml")
+
+    for world in worlds:
+        key_piece_count = 0
+
+        for location in world.get_all_item_locations():
+            if location.current_item.name == KEY_PIECE:
+                assert any(
+                    la
+                    for la in location.loc_access_list
+                    if "Eldin Volcano" in la.area.hint_regions
+                )
+                key_piece_count += 1
+
+        # With default settings, there should always be 5 key pieces.
+        # Ensures that all 5 are found and correct.
+        assert key_piece_count == 5
+
+
 def test_fi_hints() -> None:
     config_test("fi_hints.yaml")
 


### PR DESCRIPTION
## What does this address?

Changes the `open_earth_temple` setting to have multiple options (like the `open_lmf` setting):
* Open
* Shuffle Key Pieces (Eldin)
* Shuffle Key Pieces (Anywhere)

The `open` option behaves the same way as `open_earth_temple = on` did previously. The `shuffle_anywhere` option behaves the same way as `open_earth_temple = off` did previously.

The `shuffle_eldin` setting ensures that the Key Pieces are placed anywhere which has "Eldin Volcanoe" as a hint region (the same way that regional dungeon items works).


## How did/do you test these changes?

* I tested genning seeds with `open_earth_temple` set to `open` and checked the spoiler logs to confirm that no Key Pieces were placed.
* I tested genning seeds with `open_earth_temple` set to `shuffle_anywhere` and checked that all Key Pieces were placed (they also did not appear to be restricted to Eldin either).
* I tested genning a lot of seeds with `open_earth_temple` set to `shuffle_eldin` and checked that 1) the correct amount of Key Pieces were placed (I tested seeds which started with various amounts of Key Pieces) and 2) that they were all placed in Eldin Volcano (or in areas which share a hint region with Eldin, like Thrill Digger).
* I performed the previous tests with mixed interior, overworld, and trial gate ER and made sure to verify that Key Pieces were only placed in locations with the "Eldin Volcano" hint region.
* I also tested that the logic for entering Earth Temple was correct with each of the `open_earth_temple` options.
