### PR TITLE
Prevent traps mimicking items without a shop model defined

### DIFF
--- a/patches/checkpatchhandler.py
+++ b/patches/checkpatchhandler.py
@@ -95,6 +95,8 @@ def determine_check_patches(
                     for item in world.item_table.values()
                     if item.id < 200  # exclude custom items
                     and item.name not in ITEMS_NOT_TO_TRAP
+                    and item.shop_arc_name is not None
+                    and item.shop_model_name is not None
                 ]
 
                 trappable_items_setting = world.setting("trappable_items")


### PR DESCRIPTION
## What does this address?

Fixes an issue where traps would try to mimic the newly added items for bugs and treasures. These items don't have their `shop_arc_name` and `shop_model_name` fields defined (they don't need too be defined until we actually start using them - they were just added to make starting bugs/treasures nicer to implement) so seeds fail to generate if a trapped shop item tries to mimic one of these items.


## How did/do you test these changes?

I tested the seed that previously failed to generate and it generated fine :p
