### PR TITLE
Update macos runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,12 +38,12 @@ jobs:
             artifact: windows
             artifact_suffix: ""
           - name: MacOS Build x64
-            os: macos-13
+            os: macos-15-intel
             architecture: x64
             artifact: macos
             artifact_suffix: _intel
           - name: MacOS Build arm64
-            os: macos-14
+            os: macos-latest
             architecture: arm64
             artifact: macos
             artifact_suffix: _apple_silicon
@@ -62,7 +62,7 @@ jobs:
 
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-      MACOSX_DEPLOYMENT_TARGET: 13
+      MACOSX_DEPLOYMENT_TARGET: 14
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/cross-platform-tests.yaml
+++ b/.github/workflows/cross-platform-tests.yaml
@@ -15,10 +15,10 @@ jobs:
             os: windows-latest
             architecture: x64
           - name: macos-x64
-            os: macos-13
+            os: macos-15-intel
             architecture: x64
           - name: macos-arm64
-            os: macos-14
+            os: macos-latest
             architecture: arm64
           - name: linux
             os: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,10 +13,10 @@ jobs:
             os: windows-latest
             architecture: x64
           - name: MacOS x64 Tests
-            os: macos-13
+            os: macos-15-intel
             architecture: x64
           - name: MacOS arm64 Tests
-            os: macos-14
+            os: macos-latest
             architecture: arm64
           - name: Linux Tests
             os: ubuntu-latest


### PR DESCRIPTION
## What does this address?

GitHub is "retiring" their `macos-13` workflow runners. This updates the intel workflows to use `macos-15-intel` and the apple silicon workflows to use `macos-latest` (currently this is equivalent to `macos-15`).


## How did/do you test these changes?

The workflows didn't fail so I'm happy ^^'


## Notes

From the GitHub announcement:
> Notice of macOS x86_64 (Intel) architecture deprecation
Apple has discontinued support for the x86_64 (Intel) architecture going forward. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027. You should begin migrating your workloads to arm64-based (Apple Silicon) runners as soon as possible to prepare for this eventual deprecation. 