### PR TITLE
Fix Boss Rush Moldy Bug

### DIFF
--- a/data/entrance_shuffle_data.yaml
+++ b/data/entrance_shuffle_data.yaml
@@ -140,9 +140,6 @@
       - stage: D300_1
         room: 5
         index: 4
-      - stage: B300
-        room: 0
-        index: 1
       - stage: F300_5
         room: 0
         index: 3


### PR DESCRIPTION
## What does this address?

Fixes the issue where:
* Dungeon Entrance Randomizer is enabled,
* A player has beaten LMF,
* The player is in boss rush,
* The player defeats Moldarach,
* And then the player respawns after the fight at the randomized dungeon entrance.

This was all due to an incorrectly defined exit info for LMF that included the SCEN details for the exit out of the Moldarach boss room to in front of the Thunder Dragon. Removing this info fixes the issue.


## How did/do you test these changes?

I beat LMF on a DER seed. I entered and exited the boss room to make sure the entrances were behaving as expected under "normal" circumstances. I went to the Thunder Dragon and selected to battle Moldarach. I defeated Moldarach and respawned in front of the Thunder Dragon. I then went back to LMF and made sure the entrances still behaved as expected.
