### PR TITLE
Add digging mitts requirement for planting the Life Tree Seedling

### DIFF
--- a/data/world/Faron.yaml
+++ b/data/world/Faron.yaml
@@ -86,7 +86,7 @@
 
 - name: Temple of Hylia
   events:
-    Plant Life Tree Seedling: Life_Tree_Seedling
+    Plant Life Tree Seedling: Life_Tree_Seedling and Digging_Mitts
   exits:
     Sealed Temple: Nothing
   locations:


### PR DESCRIPTION
## What does this address?

Adds the missing Digging Mitts requirement for planting the Life Tree Seedling in Hylia's Temple.


## How did/do you test these changes?

I used the tracker to verify that the `Sealed Temple - Collect Fruit from the Tree of Life` location now shows a Digging Mitts requirement.
