### PR TITLE
Require whip to get to the Sky Keep control panel in the LMF room

### DIFF
--- a/data/world/Sky Keep.yaml
+++ b/data/world/Sky Keep.yaml
@@ -56,7 +56,8 @@
 - name: SK LMF Room South
   dungeon: Sky Keep
   exits:
-    SK LMF Room North: (Gust_Bellows or logic_present_bow_switches) and Bow
+    # Gust Bellows to shoot the single eye switch, whip to control the conveyor for the 5 switches.
+    SK LMF Room North: ((Gust_Bellows and Whip) or logic_present_bow_switches) and Bow
 
 
 - name: SK LMF Room North


### PR DESCRIPTION
## What does this address?

Adds Whip as a requirement to get through the LMF room of Sky Keep. The logical trick for shooting the eye switches through the barbed fences now bypasses both the Gust Bellows and the new Whip requirements.


## How did/do you test these changes?

I used the tracker and observed that Whip was now logically required for Din's and Nayru's checks (Farore's can be reached without entering the LMF room).
