### PR TITLE
Cleanup and comment logic west of FS boss door

### DIFF
--- a/data/world/Fire Sanctuary.yaml
+++ b/data/world/Fire Sanctuary.yaml
@@ -183,18 +183,20 @@
   dungeon: Fire Sanctuary
   exits:
     FS Under Magmanos Fight Room: Nothing
-    FS West of Boss Door: Can_Hit_High_Water_Plant
+    FS West of Boss Door After Lava River: Can_Hit_High_Water_Plant
 
 
-- name: FS West of Boss Door
+- name: FS West of Boss Door After Lava River
   dungeon: Fire Sanctuary
   events:
+    # Catch Plats, cross the river to the dig spot, burrow and set the river flowing OR have the shortcut enabled.
     FS Release Second Lava River: (Can_Hit_High_Water_Plant and Mogma_Mitts) or shortcut_fs_lava_flow
   exits:
+    # Hit the plant and ride the river on the magma platform.
     FS In Front of Boss Door: Can_Hit_High_Water_Plant and 'FS_Release_Second_Lava_River'
     FS West of Boss Door Before Lava River: Can_Hit_High_Water_Plant
   locations:
-    Fire Sanctuary - Plats' Chest: Mogma_Mitts and Can_Hit_High_Water_Plant
+    Fire Sanctuary - Plats' Chest: Mogma_Mitts
 
 
 - name: FS In Front of Boss Door
@@ -203,7 +205,7 @@
     Inside the Fire Sanctuary Statue: Nothing
     Fire Sanctuary Boss Room: Fire_Sanctuary_Boss_Key or boss_keys == removed
     FS Lizalfos Fight Room: Nothing
-    FS West of Boss Door: Nothing
+    FS West of Boss Door After Lava River: Nothing
     # FS In Front of Boss Door Past Bars: Opened Bars
 
 


### PR DESCRIPTION
## What does this address?

While reviewing the FS logic, I was a bit confused by the logic west of the FS boss door.

I've renamed
`FS West of Boss Door` -> `FS West of Boss Door After Lava River`
to match
`FS West of Boss Door Before Lava River`.

I've added comments to the logic within that area.

I've removed an unnecessary check for `Can_Hit_High_Water_Plant` from the Plats' chest location. It isn't needed as the player is already across the lava river and can access Plats. If the player *needed* to exit the west room such that they walked past the dig spot where they can set the lava flowing, then this requirement would be needed. As the player can just walk back out the way they came, it isn't needed.


## How did/do you test these changes?

I used the tracker to verify no changes were made to the requirements for the Plats' chest location. This is just a PR to make the logic easier to understand and *technically* more accurate. It doesn't actually change anything due to the amount of prerequisite items needed to get to this location in the first place ^^'
