### PR TITLE
Add FS logic to be a little kinder

### DIFF
--- a/data/world/Fire Sanctuary.yaml
+++ b/data/world/Fire Sanctuary.yaml
@@ -149,7 +149,9 @@
   dungeon: Fire Sanctuary
   exits:
     FS North Bridge Bottom: Nothing
-    FS North Bridge East Side: Clawshots or logic_fs_pillar_jump # No bow for the bokos?
+    # Clawshots for the targets; Bow, Slingshot, or Hook Beetle to deal with the annoying bokoblin archers; or just pillar jump.
+    # Pillar jump allows the player to hide out of the bokoblins' line of sight so they aren't really an issue.
+    FS North Bridge East Side: (Clawshots and (Bow or Slingshot or Hook_Beetle)) or logic_fs_pillar_jump
     FS South Bridge: Nothing
     FS Under Magmanos Fight Room Past Sliding Door: Nothing
 

--- a/data/world/Fire Sanctuary.yaml
+++ b/data/world/Fire Sanctuary.yaml
@@ -29,7 +29,8 @@
 - name: FS First Magmanos Room
   dungeon: Fire Sanctuary
   exits:
-    FS South Bridge: Nothing
+    # Clawshots to skip to the end of the vines, bow or slingshot to kill / stun the bokoblin archers.
+    FS South Bridge: Clawshots or Bow or Slingshot
     FS First Magmanos Room Balcony: Mogma_Mitts and Sword
     FS First Outside Section: Nothing
   locations:


### PR DESCRIPTION
## What does this address?

Adds some logic to the first magmanos room to make avoiding the bokoblin archers less obnoxious.
Adds some logic to the north outside bridge area to make avoiding the bokoblin archers while clawshotting across the bridge less obnoxious (turns out this isn't really needed since the Hook Beetle requirement earlier in the dungeon means the logic simplifies to the same as before this change).


## How did/do you test these changes?

I used the tracker and observed:

* the logic for `Fire Sanctuary - Left Rupee above Blocked Lava Source` went from.
<img width="318" height="168" alt="image" src="https://github.com/user-attachments/assets/f7e5f294-47c8-4b55-8a8c-367978060e0b" />
to
<img width="343" height="195" alt="image" src="https://github.com/user-attachments/assets/0eeb3244-862f-4df0-89d8-3320a98ee763" />

* the logic for `Fire Sanctuary - Chest from Second Trapped Mogma` remained unchanged since Hook Beetle is required to reach this location regardless.


## Notes

I noticed this while playing with a high damage multiplier and found it annoying when you only have a couple of attempts to progress unscathed before getting a game over.
