### PR TITLE
Sort Other Mods List

### DIFF
--- a/gui/settings.py
+++ b/gui/settings.py
@@ -914,8 +914,12 @@ class Settings:
 
     def generate_other_mods_list(self):
         self.main.clear_layout(self.ui.other_mods_scroll_layout)
+
+        other_mods_paths = list(OTHER_MODS_PATH.glob("*"))
+        other_mods_paths.sort()
         found_mods = []
-        for mod_path in OTHER_MODS_PATH.glob("*"):
+
+        for mod_path in other_mods_paths:
             if mod_path.is_dir():
                 mod_name = mod_path.name
 


### PR DESCRIPTION
## What does this address?

Sorts the list of other mods before displaying them on the GUI. On linux (at least, on the linux distro I use), the list the `glob` call isn't sorted alphabetically by default.


## How did/do you test these changes?

After the change, the list of other mods displayed on the GUI was ordered alphabetically.
